### PR TITLE
Mostra vida no crew Monitoring

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -237,6 +237,16 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
             statusContainer.AddChild(statusIcon);
 
+            // Health Value
+            var healthLabel = new Label()
+            {
+                Text = sensor.TotalDamage.ToString(),
+                HorizontalExpand = true,
+                ClipText = true,
+            };
+
+            statusContainer.AddChild(healthLabel);
+
             // User name
             var nameLabel = new Label()
             {


### PR DESCRIPTION
# Description

Mostra dano total no pc da Crew Monitoring
---



<summary><h1>Media</h1></summary>

![image](https://github.com/user-attachments/assets/6fe3f222-f24c-4e78-bb8f-fac27f355b80)


---

# Changelog

:cl:
- add: Label para a janela da crew monitoring
