### PR TITLE
Buffa armas do cap

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -697,10 +697,10 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedMediumLaser
-    fireCost: 100
+    fireCost: 75
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 40
+    autoRechargeRate: 50
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -35,7 +35,7 @@
       path: /Audio/SimpleStation14/Weapons/Melee/rapierhit.ogg
     damage:
       types:
-        Slash: 15
+        Slash: 25
     heavyRateModifier: 1.25
     heavyRangeModifier: 1
     heavyDamageBaseModifier: 1
@@ -49,7 +49,7 @@
   - type: ThrowingAngle
     angle: 225
   - type: Reflect
-    reflectProb: .1
+    reflectProb: .5
     spread: 90
   - type: Item
     size: Normal


### PR DESCRIPTION
Sabre teve seu dano aumentado de 15 de slash pra 25, e de refletir de 0.1 pra 0.5

Laser agora custa 75 por tiro e não 100, e sua recarga automática aumentou pra 50 ao invés de 40

