### PR TITLE
Cria o cargo Furafila para patrocinadores

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -157,7 +157,7 @@ namespace Content.Server.Connection
         private void AdminAlertIfSharedConnection(ICommonSession newSession)
         {
             var playerThreshold = _cfg.GetCVar(CCVars.AdminAlertMinPlayersSharingConnection);
-            if (playerThreshold < 0)
+            if (playerThreshold < 1)
                 return;
 
             var addr = newSession.Channel.RemoteEndPoint.Address;

--- a/Content.Shared/Administration/AdminFlags.cs
+++ b/Content.Shared/Administration/AdminFlags.cs
@@ -8,10 +8,16 @@
     {
         None = 0,
 
+
+        /// <summary>
+        ///     Permite furar filas.
+        /// </summary>
+        Furafila = 1 << 0,
+
         /// <summary>
         ///     Basic admin verbs.
         /// </summary>
-        Admin = 1 << 0,
+        Admin = 2 << 0,
 
         /// <summary>
         ///     Ability to ban people.

--- a/Content.Shared/Chat/ChatChannel.cs
+++ b/Content.Shared/Chat/ChatChannel.cs
@@ -73,7 +73,7 @@ namespace Content.Shared.Chat
         /// <summary>
         ///     Admin alerts, messages likely of elevated importance to admins
         /// </summary>
-        AdminAlert = 1 << 12,
+        AdminAlert = 2 << 12,
 
         /// <summary>
         ///     Admin chat


### PR DESCRIPTION
Cria o cargo Furafila para patrocinadores sem com que eles consigam ver os Adminalerta.

Espero que não de merda.
