### PR TITLE
ChatSan hotfix

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -82,8 +82,9 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "kkkkk", "chatsan-laughs" },   // mas como não tem sistema que usa regex pronto
         { "kkkk", "chatsan-laughs" },    // vai assim mesmo até segunda ordem
         { "kkk", "chatsan-laughs" },     // também odeio muito que isso não tá no locale de pt-br
-        { "kk", "chatsan-laughs" },      // c'est lá vie... eh a vida...
-        { "k", "chatsan-laughs" },       // ah, a ordem importa; os maiores tem que vir primeiro, se não ele vai pegar um dos menores e enviar o resto da mensagem
+        // conflita com "Ok", então comentados até segunda ordem
+        // { "kk", "chatsan-laughs" },      // c'est lá vie... eh a vida...
+        // { "k", "chatsan-laughs" },       // ah, a ordem importa; os maiores tem que vir primeiro, se não ele vai pegar um dos menores e enviar o resto da mensagem
         { "o7", "chatsan-salutes" },
         { ";_;7", "chatsan-tearfully-salutes"},
         { "idk", "chatsan-shrugs" },

--- a/Resources/Locale/pt-BR/speech/speech-chatsan.ftl
+++ b/Resources/Locale/pt-BR/speech/speech-chatsan.ftl
@@ -336,11 +336,13 @@ chatsan-replacement-1119 = chefe da segurança
 chatsan-word-1120 = hop
 chatsan-replacement-1120 = chefe dos funcionários
 
-chatsan-word-1121 = n
-chatsan-replacement-1121 = não
 
-chatsan-word-1122 = s
-chatsan-replacement-1122 = sim
+# comentados até segunda ordem por que :n e :s são os radios da sec e sci
+# chatsan-word-1121 = n
+# chatsan-replacement-1121 = não
+
+# chatsan-word-1122 = s
+# chatsan-replacement-1122 = sim
 
 chatsan-word-1123 = mn
 chatsan-replacement-1123 = mano

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -503,8 +503,8 @@
     chatsan-word-1118: chatsan-replacement-1118
     chatsan-word-1119: chatsan-replacement-1119
     chatsan-word-1120: chatsan-replacement-1120
-    chatsan-word-1121: chatsan-replacement-1121
-    chatsan-word-1122: chatsan-replacement-1122
+    # chatsan-word-1121: chatsan-replacement-1121
+    # chatsan-word-1122: chatsan-replacement-1122
 
 - type: accent
   id: liar


### PR DESCRIPTION
Hotfix com a correção de algumas coisas bestas;

- Comentado "s" e "n" por conflitarem com os rádios de sec e sci;
- Comentado "k" e "kk" por conflitarem com palavras normais, como "Ok"