### PR TITLE
atualiza um pouco a ion storm e muda borg med pro dept de silicios

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -95,7 +95,6 @@
   - Psychologist
   - Paramedic
   - SeniorPhysician
-  - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
 
 - type: department
   id: Security
@@ -133,6 +132,7 @@
   roles:
   - Borg
   - StationAi
+  - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
 
 - type: department
   id: Specific

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -759,3 +759,11 @@
     Druid: 1
     #Potentially Harmful Lawsets
     Tyrant: 0.25
+    Quarantine: 0.5
+    CCTV: 0.5
+    NTAgressive: 0.5  
+    #Harmful Lawsets
+    Quarantine: 0.5
+    CCTV: 0.5
+    PlasmaFlood: 0.5
+    SyndicateStatic: 0.5


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

coloquei mais set de leis de IA possiveis para ion storm e mudei o borg med para o departamento de silicios.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Emilly
- tweak: mais leis para ion storm, borg med agora faz parte do dept de silicio ao inves da med


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Novos lawsets adicionados ao pool de seleção aleatória de leis de silício durante Ion Storms, incluindo categorias de lawsets potencialmente nocivos e nocivos.
- **Ajustes**
  - O papel de MedicalBorg foi transferido do departamento Médico para o departamento de Silício.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->