### PR TITLE
Deitado, carregado e tudo entre desliga colisão no EE

### DIFF
--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -35,7 +35,7 @@ public sealed class StandingStateSystem : EntitySystem
 
     private void OnMobTargetCollide(Entity<StandingStateComponent> ent, ref AttemptMobTargetCollideEvent args)
     {
-        if (!ent.Comp.Standing)
+        if (ent.Comp.CurrentState is not StandingState.Standing)
         {
             args.Cancelled = true;
         }
@@ -43,7 +43,7 @@ public sealed class StandingStateSystem : EntitySystem
 
     private void OnMobCollide(Entity<StandingStateComponent> ent, ref AttemptMobCollideEvent args)
     {
-        if (!ent.Comp.Standing)
+        if (ent.Comp.CurrentState is not StandingState.Standing)
         {
             args.Cancelled = true;
         }


### PR DESCRIPTION
EE tem um enumerator para os estados de Standing, agora mob collision respeita isso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções de Bugs**
  - Melhorada a detecção do estado de "em pé" de entidades durante eventos de colisão, garantindo que colisões sejam corretamente canceladas quando a entidade não estiver em pé.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->