### PR TITLE
arrumando erro yaml do canvas

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/canvas.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/canvas.yml
@@ -3,9 +3,6 @@
   id: CanvasBase
   name: Canvas
   description: A canvas to Paint.
-  Canvas:
-    Height: 16
-    Width: 16
   components:
   - type: Sprite
     sprite: Objects/Misc/artstuff.rsi
@@ -44,9 +41,6 @@
   id: CanvasMedium
   name: Medium Canvas
   description: A medium sized canvas to paint.
-  Canvas:
-    Height: 16
-    Width: 16
   components:
   - type: Canvas
     height: 16
@@ -57,9 +51,6 @@
   id: CanvasLarge
   name: Large Canvas
   description: A big sized canvas to paint.
-  Canvas:
-    Height: 16
-    Width: 32
   components:
   - type: Canvas
     height: 16
@@ -70,9 +61,6 @@
   id: CanvasGiant
   name: Giant Canvas
   description: A giant sized canvas to paint.
-  Canvas:
-    Height: 16
-    Width: 32
   components:
   - type: Canvas
     height: 32


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refatoração**
  - Removidas declarações duplicadas de altura e largura dos protótipos de canvas, centralizando essas informações apenas na seção de componentes de cada entidade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->