### PR TITLE
arruma o server packaging

### DIFF
--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -193,7 +193,6 @@ public static class ServerPackaging
                 contentAssemblies.Add(fileName);
             }
         }
-        pass.InjectFileFromDisk("build.json", Path.Combine(contentDir, "Content.Server", "build.json"));
 
         await RobustSharedPackaging.DoResourceCopy(
             Path.Combine("RobustToolbox", "bin", "Server",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refatoração**
  - Removida a inclusão explícita do arquivo "build.json" no processo de empacotamento de recursos do servidor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->