### PR TITLE
Tradução da aba de antags presente no livro guia

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
@@ -1,13 +1,13 @@
 <Document>
-  # Antagonists
+  # Antagonistas
 
-  Antagonists are the driving force of every shift, usually creating conflict and defying the crew. Their goals can vary a lot, but they usually require some thievery, sabotage, or murder.
+  Os Antagonistas são a força motriz de cada turno, geralmente criando conflitos e desafiando a tripulação. Seus objetivos podem variar bastante, mas geralmente envolvem roubo, sabotagem ou assassinato.
 
-  ## Various Antagonists
+  ## Vários Antagonistas
 
-  Antagonists can take many forms, like:
-  - Nuclear operatives, with the goal of infiltrating and destroying the station.
-  - Traitors infiltrating the crew who can assassinate targets and steal high value items.
-  - Space Ninjas, masters of espionage and sabotage, who are equipped with special gear.
-  - Several non-humanoid creatures, who usually just try to bring down as many crewmembers as they can.
+  Os Antagonistas podem assumir diversas formas, como:
+  - Operadores nucleares, com o objetivo de se infiltrar e destruir a estação.
+  - Traidores que se infiltram na tripulação e podem assassinar alvos e roubar itens de alto valor.
+  - Ninjas Espaciais, mestres da espionagem e sabotagem, equipados com equipamentos especiais.
+  - Diversas criaturas não humanoides, que geralmente tentam derrubar o máximo de tripulantes possível.
 </Document>

--- a/Resources/ServerInfo/Guidebook/Antagonist/BloodCult.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/BloodCult.xml
@@ -1,184 +1,182 @@
 <Document>
-  Be ware - this document is just almost a full copy of /tg/ station blood cult guide.
+  Cuidado - este documento é quase uma cópia completa do guia do culto de sangue da estação /tg/.
 
-  # Blood Cult
+  # Culto de Sangue
 
-  Even in the far future, some things are never quite understood. There are things that lurk in the darkness of space,
-  unspeakable horrors of ancient power that wish to bring ruin to the universe and to shape it into their image. They
-  reach out from the void, and turn the minds of mortal men and women in their favor in hopes that one day they shall be
-  brought once more into this plane of existence.
+  Mesmo em um futuro distante, algumas coisas nunca são totalmente compreendidas. Há coisas que espreitam na escuridão do espaço,
+  horrores indizíveis de poder ancestral que desejam trazer a ruína ao universo e moldá-lo à sua imagem. Eles
+  estão surgindo do vazio e influenciam as mentes de homens e mulheres mortais a seu favor, na esperança de que um dia sejam
+  trazidos novamente a este plano de existência.
 
-  The Geometer of Blood, Nar-Sie, has sent a number of her followers to Space Station 14. As a cultist, you have an
-  abundance of cult magics at your disposal, something for all situations. You must work with your brethren to summon an
-  avatar of your eldritch goddess!
+  A Geômetra de Sangue, Nar-Sie, enviou vários de seus seguidores para a Estação Espacial 14. Como cultista, você tem
+  uma abundância de magias de culto à sua disposição, algo para todas as situações. Você deve trabalhar com seus irmãos para invocar um
+  avatar de sua deusa sobrenatural!
 
-  ## Objectives
+  ## Objetivos
 
-  Your objective requires you to sacrifice a certain crewmember and summon Nar-Sie.
+  Seu objetivo requer que você sacrifique um certo membro da tripulação e invoque Nar-Sie.
 
-  The general path of action of the cult and those in it:
+  O caminho geral de ação do culto e daqueles que o compõem:
 
-  - 1. From a discrete location, contact your allies. You can do it by speaking Eldritch language - everyone in the cult
-  can hear you when you speak it.
-  - 2. Find an area to convert into a base, usually accessible by one or more members of the cult, but well-hidden
-  enough that security or crew won't find it easily.
-  - 3. Setup a teleport rune, so all cultists can access it.
-  - 4. Setup an empowering rune and then prepare up to 4 blood spells. Stun spells are your bread and butter - but
-  diversifying with spells like EMP, Teleport, Blood Rites, etc. will ensure you're ready for anything.
-  - 5. Convert new members, or sacrifice implanted crew, on the offering rune. Combine the filled soul shard from
-  sacrificed humans to create powerful cult constructs!
-  - 6. Use teamwork to find your sacrifice target.
-  - 7. Kill the sacrifice target and place them on an offer rune with 3 cultists nearby.
-  - 8. Prepare to summon Nar-Sie. She can only be summoned in a few locations and the crew will fight desperately to
-  stop you! Make sure you have enough cultists and equipment to withstand their assault.
-  - 9. Gather 10 cultists on the final rune to summon Nar-Sie!
+  - 1. De um local discreto, entre em contato com seus aliados. Você pode fazer isso falando a língua dos Eldritch - todos no culto
+  podem ouvi-lo quando você a fala.
+  - 2. Encontre uma área para converter em base, geralmente acessível a um ou mais membros do culto, mas bem escondida
+  o suficiente para que a segurança ou a tripulação não a encontrem facilmente.
+  - 3. Configure uma runa de teletransporte para que todos os cultistas possam acessá-la.
+  - 4. Configure uma runa de fortalecimento e prepare até 4 magias de sangue. Magias de atordoamento são o seu ganha-pão - mas
+  diversificar com magias como PEM, Teletransporte, Ritos de Sangue, etc. garantirá que você esteja pronto para qualquer coisa.
+  - 5. Converta novos membros ou sacrifique a tripulação implantada na runa de oferenda. Combine o fragmento de alma preenchido de
+  humanos sacrificados para criar poderosos constructos do culto!
+  - 6. Use o trabalho em equipe para encontrar seu alvo de sacrifício.
+  - 7. Mate o alvo do sacrifício e coloque-o em uma runa de oferta com 3 cultistas por perto.
+  - 8. Prepare-se para invocar Nar-Sie. Ela só pode ser invocada em alguns locais e a tripulação lutará desesperadamente para
+  detê-lo! Certifique-se de ter cultistas e equipamentos suficientes para resistir ao ataque.
+  - 9. Reúna 10 cultistas na runa final para invocar Nar-Sie!
 
-  ## Ritual Dagger
+  ## Adaga Ritual
 
   <Box>
     <GuideEntityEmbed Entity="RitualDagger" Caption="Ritual Dagger"/>
   </Box>
 
-  Your dagger is your most important tool and has several functions:
+  Sua adaga é sua ferramenta mais importante e tem várias funções:
 
-  - You can draw runes with it.
-  - Hitting a non-cultist with it will result in you stabbing them (huh), dealing 15 piercing damage.
-  - Using it on the rune with erase it.
-  - Using it on the cult barrier will remove it.
+  - Você pode desenhar runas com ela.
+  - Atingir um não cultista com ela resultará em você esfaqueá-lo (hum), causando 15 de dano perfurante.
+  - Usá-la na runa a apagará.
+  - Usá-la na barreira do culto a removerá.
 
-  ## Minor Runes
+  ## Runas Menores
 
-  These are minor runes cultists can draw anywhere on the station.
+  Estas são runas menores que os cultistas podem desenhar em qualquer lugar da estação.
 
   <Box Orientation="Vertical" HorizontalAlignment="Center">
     <Box>
       <GuideEntityEmbed Entity="CultRuneOffering" Caption="Rune of Offering"/>
     </Box>
-    Can be used to convert or sacrifice targets on it. It takes two cultists to convert someone.
+    Pode ser usado para converter ou sacrificar alvos. São necessários dois cultistas para converter alguém.
 
-    [bold]REMINDER: One cultist is required to sacrifice a dead body and three for a live one,
-    standing adjacent to the rune. Each sacrifice will add to the Cult's total number of sacrifices, which are used
-    to revive deceased bretheren instantly over a Revival Rune.[/bold]
+    [bold]LEMBRETE: Um cultista precisa sacrificar um cadáver e três para um vivo,
+    permanecendo ao lado da runa. Cada sacrifício será adicionado ao número total de sacrifícios do Culto, que são usados
+    para reviver irmãos falecidos instantaneamente com uma Runa de Renascimento.[/bold]
 
     <Box>
       <GuideEntityEmbed Entity="CultRuneEmpower" Caption="Rune of Empower"/>
     </Box>
-    Grants a buff allowing cultists to prepare greater amounts of blood magic at far less of a cost. While you have
-    it, the spell count is capped at 4 instead of 1. Additionally, drawing runes takes far less time and you don't
-    lose as much blood while doing it.
+    Concede um bônus que permite aos cultistas preparar maiores quantidades de magia de sangue a um custo muito menor. Enquanto você a tiver,
+    a contagem de magias será limitada a 4 em vez de 1. Além disso, desenhar runas leva muito menos tempo e você não
+    perde tanto sangue ao fazê-lo.
 
     <Box>
       <GuideEntityEmbed Entity="CultRuneTeleport" Caption="Rune of Teleportation"/>
     </Box>
-    This rune warps everything above it to another teleport rune when used. Creating a teleport rune will allow you to
-    set a tag for it.
+    Esta runa teletransporta tudo acima dela para outra runa de teletransporte quando usada. Criar uma runa de teletransporte permitirá que você
+    defina uma tag para ela.
 
     <Box>
       <GuideEntityEmbed Entity="CultRuneRevive" Caption="Rune of Rejuvenation"/>
     </Box>
-    Placing a cultist corpse on the rune and activating it will bring them back to life. Consumes one charge on use
-    and starts with three freebie revivals, so use it sparingly. .
+    Colocar um cadáver de cultista na runa e ativá-la o trará de volta à vida. Consome uma carga ao usar
+    e começa com três renascimentos gratuitos, então use com moderação.
 
     <Box>
       <GuideEntityEmbed Entity="CultRuneBarrier" Caption="Rune of Barrier"/>
     </Box>
-    When invoked, makes a temporary barrier to block passage.
+    Quando invocado, cria uma barreira temporária para bloquear a passagem.
 
     <Box>
       <GuideEntityEmbed Entity="CultRuneSummoning" Caption="Rune of Summoning"/>
     </Box>
-    This rune allows you to instantly summon any living cultist to the rune, consuming it afterward. Does not work on
-    restrained cultists who are buckled or being pulled.
+    Esta runa permite que você invoque instantaneamente qualquer cultista vivo para a runa, consumindo-a em seguida. Não funciona em
+    cultistas imobilizados que estejam presos ou sendo puxados.
 
     <Box>
       <GuideEntityEmbed Entity="CultRuneBloodBoil" Caption="Rune of Boiling Blood"/>
     </Box>
-    When invoked, it saps some health from the invokers to send three damaging pulses to anyone who can see the
-    rune and ignites them.
+    Quando invocada, ela drena um pouco da vida dos invocadores para enviar três pulsos danosos a qualquer um que possa ver a runa
+    e os incendeia.
   </Box>
 
-  ## Major runes
+  ## Runas Principais
 
-  These are the major runes cultists can draw once they meet certain conditions. They need a free 3x3 space, and can only
-  be summoned in 3 areas around the station (or have 3 global charges). Depleting all of them makes you unable to draw
-  them anymore. So be careful not to consume all of them with apocalypse runes or you'll never be able to summon
+  Estas são as runas principais que os cultistas podem sacar quando atendem a certas condições. Elas precisam de um espaço livre de 3x3 e só podem
+  ser invocadas em 3 áreas ao redor da estação (ou ter 3 cargas globais). Esgotar todas elas torna você incapaz de sacá-las
+  mais. Portanto, tome cuidado para não consumir todas elas com runas de apocalipse ou você nunca mais poderá invocar
   Nar'Sie!
 
   <Box>
     <GuideEntityEmbed Entity="CultRuneApocalypse" Caption="Rune of Apocalypse"/>
   </Box>
 
-  A harbinger of the end times. It scales depending on the crew's strength relative to the cult. Effect includes a
-  massive EMP, total blackout, solar flare and if the cult is doing poorly, certain events. If the cult makes up to
-  less than 15% of current players, and an apocalypse rune is activated, a random event will
-  occur:
-  - Immovable Rod x3
-  - Mouse Migration x2
-  - Meteor Swarm x2
-  - Vent Crickets x3
-  - Four Random Anomalies
-  - Kudzu Growth x2
-  - Vendor Mimics x2
+  Um prenúncio do fim dos tempos. Ele escala dependendo da força da tripulação em relação ao culto. O efeito inclui um
+  PEM massivo, apagão total, explosão solar e, se o culto estiver indo mal, certos eventos. Se o culto representar
+  menos de 15% dos jogadores atuais e uma runa de apocalipse for ativada, um evento aleatório
+  ocorrerá:
+  - Bastão Imóvel x3
+  - Migração de Ratos x2
+  - Enxame de Meteoros x2
+  - Grilos de Ventilação x3
+  - Quatro Anomalias Aleatórias
+  - Crescimento de Kudzu x2
+  - Mímicos de Vendedores x2
 
   <Box>
     <GuideEntityEmbed Entity="CultRuneDimensionalRending" Caption="Rune of Dimensional Rending"/>
   </Box>
-  This rune tears apart dimensional barriers, calling forth the Geometer. To start drawing it the requested target
-  must have already been sacrificed. Starting to draw this rune alarms the entire station of its location. The caster
-  must be defended for 45 seconds before it's complete.
-  After it's drawn, 10 cultists, constructs, or summoned ghosts must stand on the rune, which can then be invoked to
-  manifest Nar'Sie itself.
+  Esta runa rompe barreiras dimensionais, invocando o Geômetra. Para começar a desenhar, o alvo solicitado
+  deve já ter sido sacrificado. Começar a desenhar esta runa alerta toda a estação sobre sua localização. O conjurador
+  deve ser defendido por 45 segundos antes de ser concluído.
+  Após ser desenhada, 10 cultistas, constructos ou fantasmas invocados devem ficar sobre a runa, que pode então ser invocada para
+  manifestar a própria Nar'Sie.
 
-  ## Blood Spells
+  ## Feitiços de Sangue
 
-  Blood Spells are limited-use blood magic spells that dissipate after they're spent, and they're your bread and butter
-  when fighting the crew. Blood Spells can be created at any time via a menu when right clicking your character.
-  However, blood spells created without an Empowering Rune will take longer, cause significant blood loss, and
-  will cap your spell count at a measly one
+  Feitiços de Sangue são feitiços de magia de sangue de uso limitado que se dissipam após serem gastos e são seu ganha-pão
+  ao lutar contra a tripulação. Feitiços de Sangue podem ser criados a qualquer momento através de um menu ao clicar com o botão direito do mouse no seu personagem.
+  No entanto, feitiços de sangue criados sem uma Runa de Fortalecimento levarão mais tempo, causarão perda significativa de sangue e
+  limitarão sua contagem de feitiços a um número irrisório.
 
-  A good tip is to make sure to try and have a stun spell and a teleport spell with you to escape risky situations. This
-  will leave only two other options for spells though, so carefully choose what you think might help best for a
-  particular situation.
+  Uma boa dica é certificar-se de ter um feitiço de atordoamento e um feitiço de teletransporte com você para escapar de situações arriscadas. Isso deixará apenas duas outras opções de magias, então escolha cuidadosamente o que você acha que pode ajudar melhor em uma situação específica.
 
 
-  ## Constructs
+  ## Construtos
 
-  Shades and constructs are slaved to their masters will. They must follow the orders of their master at any cost. They
-  are capable of grasping intent, unlike synthetic beings. Constructs created by cultists automatically become cultists
-  themselves, allowing them to identify their team mates, and even count for the escape objective.
+  Sombras e construtos são escravos da vontade de seus mestres. Eles devem seguir as ordens de seu mestre a qualquer custo. Eles
+  são capazes de captar intenções, ao contrário de seres sintéticos. Construtos criados por cultistas tornam-se cultistas automaticamente
+  eles próprios, permitindo-lhes identificar seus companheiros de equipe e até mesmo contar para o objetivo de fuga.
 
   <Box>
     <GuideEntityEmbed Entity="ShadeCult" Caption="Shade"/>
   </Box>
-  Shades are fragile, but being recaptured into their soul shard heals them. Useful if you quickly need someone to help
-  you activate a rune.
+  Sombras são frágeis, mas serem recapturadas em seu fragmento de alma as curam. Útil se você precisar rapidamente de alguém para ajudar
+  você a ativar uma runa.
 
   <Box>
     <GuideEntityEmbed Entity="ConstructArtificer" Caption="Artificer"/>
   </Box>
-  The artificer is the "drone" of the cult. It can construct cult-floors, walls and reinforced walls, as well as take
-  apart the station, but its main purpose is to provide the materials to construct additional constructs. It can create
-  new soul stones or shells after a certain time.
+  O artífice é o "drone" do culto. Ele pode construir pisos, paredes e muros reforçados para o culto, além de desmontar
+  a estação, mas seu principal objetivo é fornecer os materiais para a construção de construções adicionais. Ele pode criar
+  novas pedras da alma ou conchas após um certo tempo.
 
   <Box>
     <GuideEntityEmbed Entity="ConstructWraith" Caption="Wraith"/>
   </Box>
-  The wraith is a tiny bit more fragile than a human but has a strong melee attack. It can become invisible and travel
-  through closed doors and even walls by using it's phase shift ability.
+  O espectro é um pouco mais frágil que um humano, mas possui um forte ataque corpo a corpo. Ele pode se tornar invisível e atravessar
+  portas fechadas e até paredes usando sua habilidade de mudança de fase.
 
   <Box>
     <GuideEntityEmbed Entity="ConstructJuggernaut" Caption="Juggernaut"/>
   </Box>
-  Juggernauts are strong, slow and have lots of health. They can destroy any wall by simply punching it and do more
-  damage than Wraiths. They cannot be pushed or grabbed and even have a force-wall ability similar to the wizard spell.
+  JUggernauts são fortes, lentos e têm muita vida. Eles podem destruir qualquer parede com um simples soco e causar mais
+  dano do que Espectros. Eles não podem ser empurrados ou agarrados e até têm uma habilidade de parede de força semelhante à magia de mago.
 
-  ## Tips
-  - Only cultists can know a rune's name and effects by examining it.
-  - Always be ready to summon a cultist in trouble. You can't summon them if they're already cuffed.
-  - Keeping a shade in a Soulstone Shard with you will allow you to use two-person runes by yourself, by releasing and
-  then recapturing the shade.
-  - Cultists often find a use for medibots. Having a single bot with a low threshold, backed up by brutepacks or pylons,
-  can keep your cult in fighting shape.
-  - The EMP spell and Apocalypse Rune are both incredibly useful. They can give you access almost anywhere, just don't
-  forget your crowbar!
+  ## Dicas
+  - Somente cultistas podem saber o nome e os efeitos de uma runa examinando-a.
+  - Esteja sempre pronto para invocar um cultista em apuros. Você não pode invocá-lo se ele já estiver algemado.
+  - Manter uma sombra em um Fragmento de Pedra da Alma com você permitirá que você use runas de duas pessoas sozinho, liberando e
+  recapturando a sombra.
+  - Cultistas frequentemente encontram utilidade para medibots. Ter um único bot com um limite baixo, apoiado por grupos de brutamontes ou torres,
+  pode manter o seu culto em forma para lutar.
+  - A magia PEM e a Runa do Apocalipse são incrivelmente úteis. Elas podem te dar acesso a quase qualquer lugar, só não
+  se esqueça do seu pé de cabra!
 </Document>

--- a/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
@@ -1,7 +1,7 @@
 <Document>
-  # Minor Antagonists
+  #Antagonistas Menores
 
-  Most if not all Minor Antagonists are ghost-controlled roles that gives dead people new ways to cause chaos around the station. They are spawned by random events.
+  A maioria, senão todos os Antagonistas Menores, são personagens controlados por fantasmas que dão aos mortos novas maneiras de causar o caos na estação. Eles surgem por eventos aleatórios.
 
   # Revenant
 
@@ -10,51 +10,51 @@
     <GuideEntityEmbed Entity="Ectoplasm" Caption=""/>
   </Box>
 
-  A Revenant is given powers to haunt the crew and steal life essence from them.
+  Um Revenant recebe poderes para assombrar a tripulação e roubar essência vital deles.
 
-  ## Essence
+  ## Essência
 
-  - Your [color=#a4885c]essence[/color] is your very own life force and a way to use abilities for a cost, don't let it drop to 0.
-  - To gain [color=#a4885c]essence[/color] you first inspect various souls for their worth. More worthy souls grant more essence.
-  However merely checking their worth isn't enough for collecting [color=#a4885c]essence[/color]. You must siphon it either when the victim is critical, dead, or sleeping.
-  - A good start is to go to medical or dorms but be wary, you are vulnerable to attacks when you siphon a soul. Taking damage reduces your [color=#a4885c]essence[/color]! So plan your attacks wisely.
+  - Sua [color=#a4885c]essência[/color] é sua própria força vital e uma forma de usar habilidades por um custo, não deixe que ele caia para 0.
+  - Para obter [color=#a4885c]essência[/color], você primeiro inspeciona várias almas para verificar seu valor. Almas mais dignas concedem mais essência.
+  No entanto, apenas verificar seu valor não é suficiente para coletar [color=#a4885c]essência[/color]. Você deve ceifa-la quando a vítima estiver em estado crítico, morta ou dormindo.
+  - Um bom começo é ir ao pronto-socorro ou aos dormitórios, mas tenha cuidado, você fica vulnerável a ataques ao ceifar uma alma. Receber dano reduz sua [color=#a4885c]essência[/color]! Portanto, planeje os seus ataques com sabedoria.
 
-  ## Shop And Powers
+  ## Loja e Poderes
 
-  - Using [color=#a4885c]stolen essence[/color] gotten from siphoning souls, you can gain skills for mischief such as environmental destruction, electrical disruption, and electrocution through the shop.
-  - Using powers leave you vulnerable to attacks for some time, plan ahead and prepare before attacking.
+  - Usando [color=#a4885c]essência roubada[/color] obtida ao sugar almas, você pode adquirir habilidades para causar danos, como destruição ambiental, interrupção elétrica e eletrocussão na loja.
+  - Usar poderes deixa você vulnerável a ataques por algum tempo, então planeje e prepare-se antes de atacar.
 
-  # Rat King
+  # Rei Rato
 
   <Box>
     <GuideEntityEmbed Entity="MobRatKing" Scale="2.4" Caption="Normal Rat King"/>
     <GuideEntityEmbed Entity="MobRatKingBuff" Caption="Buff Rat King"/>
   </Box>
 
-  A Rat King is a giant rat capable of setting a nest and creating rats to do their bidding (usually to get food).
+  Um Rei Rato é um rato gigante capaz de construir um ninho e criar ratos para atender às suas ordens (geralmente para obter comida).
 
-  ## Abilities
+  ## Habilidades
 
-  Abilities come at a cost to the Rat King's hunger. Simply eating replenishes it.
+  As habilidades têm um custo para a fome do Rei Rato. Simplesmente comer a repõe.
 
   <Box>
    <GuideEntityEmbed Entity="MobMouse" Caption="Normal Mouse"/>
    <GuideEntityEmbed Entity="MobRatServant" Caption="Rat Servant"/>
   </Box>
-  - Raise an Army of [color=#a4885c]Rat Servants[/color].
-  - Conjure a cloud of ammonia.
+  - Crie um Exército de [color=#a4885c]Servos Ratos[/color].
+  - Conjure uma nuvem de amônia.
 
-  # Space Dragon
+  # Dragão Espacial
 
   <Box>
     <GuideEntityEmbed Entity="MobDragon" Caption=""/>
   </Box>
 
-  A Space Dragon is a giant dragon that creates space carp rifts and eats the crew.
+  Um Dragão Espacial é um dragão gigante que cria fendas de carpas espaciais e devora a tripulação.
 
-  ## Abilities
+  ## Habilidades
 
-  - Devour critical or dead victims.
+  - Devorar vítimas críticas ou mortas.
 
   <Box>
     <GuideEntityEmbed Entity="MobCarp" Caption=""/>
@@ -62,6 +62,6 @@
     <GuideEntityEmbed Entity="MobCarp" Caption=""/>
   </Box>
 
-  - Summon a Carp Rift that periodically spawns [color=#a4885c]Space Carp[/color].
+  - Invoca uma Fenda de carpa que periodicamente gera [color=#a4885c]Carpas Espaciais[/color].
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
@@ -1,47 +1,47 @@
 <Document>
-  # Nuclear Operatives
+  # Operativos Nucleares
 
-  AUTOTELL ON STANDBY. YOUR OBJECTIVES ARE SIMPLE. DELIVER THE PAYLOAD AND GET OUT BEFORE THE PAYLOAD DETONATES. BEGIN MISSION.
+  AUTODELL EM ESPERA. SEUS OBJETIVOS SÃO SIMPLES. ENTREGUE A CARGA E SAIA ANTES QUE ELA DETONE. COMECE A MISSÃO.
 
-  If you hear this message then congratulations! You have just been chosen to be a nuclear operative for the syndicate. You have one goal, to blow up the space station with a nuclear fission explosive.
+  Se você ouvir esta mensagem, parabéns! Você acaba de ser escolhido para ser um operativo nuclear do sindicato. Você tem um objetivo: explodir a estação espacial com um explosivo de fissão nuclear.
 
-  ## Operatives
+  ## Operativos
 
-  Your team may contain varying amounts of three different roles:
-  - The [color=#a4885c]Nukie Commander[/color] wears the unique commander’s hardsuit, and will create or approve of the battle plan.
+  Sua equipe pode ter quantidades variáveis de três funções diferentes:
+  - O [color=#a4885c]Comandante Nukie[/color] usa o traje especial exclusivo de comandante e criará ou aprovará o plano de batalha.
   <Box>
     <GuideEntityEmbed Entity="ClothingOuterHardsuitSyndieCommander" Caption="Commander Hardsuit"/>
   </Box>
 
-  - The [color=#a4885c]Nukie Agent[/color] wears the blood-red medic hardsuit, and can act as a combat medic for the mission.
+  - O [color=#a4885c]Médico Nukie[/color] veste o traje médico vermelho-sangue e pode atuar como um médico de combate na missão.
   <Box>
     <GuideEntityEmbed Entity="ClothingOuterHardsuitSyndieMedic" Caption="Blood-Red Medic Hardsuit"/>
   </Box>
 
-  - Regular [color=#a4885c]Nuclear Operatives[/color], who have the normal blood red hardsuit.
+  - [color=#a4885c]Operadores Nucleares[/color] regulares, que têm o traje rígido vermelho-sangue normal.
   <Box>
     <GuideEntityEmbed Entity="ClothingOuterHardsuitSyndie" Caption="Blood Red Hardsuit"/>
   </Box>
 
-  If you have been selected for either of these special roles but don't feel ready, one of your teammates can take responsibility.
+  Se você foi selecionado para qualquer uma dessas funções especiais, mas não se sente preparado, um de seus companheiros de equipe pode assumir a responsabilidade.
 
-  ## Preparation
+  ## Preparação
 
-  Taking on a whole station in a fight is a difficult job, luckily you are well prepared for the job. Every operative has an [color=#a4885c]Uplink[/color]. It comes with 40 [color=#a4885c]Telecrystals[/color], which you can use to purchase gear. What you get depends on the strategy picked by your commander or voted for by the team. Only your commander and agent will have passenger access, but no external airlock access. This means you will need something to hack or blast your way onto the station.  In general you should need some weapons, something to breach doors, and utility/healing.
+  Enfrentar uma estação inteira em combate é uma tarefa difícil; felizmente, você está bem preparado para a tarefa. Cada agente possui um [color=#a4885c]Uplink[/color]. Ele vem com 40 [color=#a4885c]Telecristais[/color], que você pode usar para comprar equipamentos. O que você recebe depende da estratégia escolhida pelo seu comandante ou votada pela equipe. Apenas seu comandante e agente terão acesso a passageiros, mas não à câmara de descompressão externa. Isso significa que você precisará de algo para invadir ou explodir a estação. Em geral, você precisará de algumas armas, algo para arrombar portas e utilidade/cura.
 
   <Box>
     <GuideEntityEmbed Entity="BaseUplinkRadio40TC" Caption="The Uplink"/>
   </Box>
 
-  ## Getting to the Station
+  ## Chegando à Estação
 
-  After gearing up and creating a plan, grab a jetpack from your armory and go with your other operatives to the [color=#a4885c]Nukie Shuttle[/color]. Here you will find some extra explosives and tools, as well as your nuke and nuke codes.
-  You will find an [color=#a4885c]IFF Console[/color] on the shuttle, it allows you to hide from other ships and mass scanners. Make sure that [color=#a4885c]Show IFF[/color] and [color=#a4885c]Show Vessel[/color] are toggled off to hide your shuttle from the crew. When everyone is ready, FTL to the station and fly to it with a jetpack. Don't forget the nuclear fission explosive on your ship if you are going to use it, and definitely don't forget the nuke codes or pinpointer.
+  Depois de se preparar e criar um plano, pegue um jetpack no seu arsenal e vá com seus outros agentes para a [color=#a4885c]Nave Espacial Nukie[/color]. Lá você encontrará alguns explosivos e ferramentas extras, bem como sua bomba nuclear e seus códigos nucleares.
+  Você encontrará um [color=#a4885c]Console IFF[/color] na nave espacial, que permite que você se esconda de outras naves e scanners de massa. Certifique-se de que [color=#a4885c]Mostrar IFF[/color] e [color=#a4885c]Mostrar Embarcação[/color] estejam desativados para esconder sua nave espacial da tripulação. Quando todos estiverem prontos, vá para a estação e voe até ela com um jetpack. Não se esqueça do explosivo de fissão nuclear na sua nave se for usá-lo, e definitivamente não se esqueça dos códigos nucleares ou do localizador.
 
-  ## The Disk
+  ## O Disco
 
-  You will notice that each operative starts with a [color=#a4885c]Pinpointer[/color]. This device is one of the most important items to the mission, and you should keep it with you at all times. Turn on the pinpointer when you arrive at the station and it will always point to the [color=#a4885c]Nuke Disk[/color], your next objective.
-  The nuke disk belongs to the captain, who will almost always have it on them. Follow the direction of the arrow on the pinpointer to the disk, and do whatever it takes to get it.
+  Você notará que cada agente começa com um [color=#a4885c]Apontador[/color]. Este dispositivo é um dos itens mais importantes para a missão e você deve mantê-lo com você o tempo todo. Ligue o apontador ao chegar à estação e ele sempre apontará para o [color=#a4885c]Disco Nuclear[/color], seu próximo objetivo.
+  O disco nuclear pertence ao capitão, que quase sempre o terá consigo. Siga a direção da seta no apontador até o disco e faça o que for preciso para obtê-lo.
 
 
   <Box>
@@ -49,40 +49,40 @@
     <GuideEntityEmbed Entity="NukeDisk" Caption="The Nuke Disk"/>
   </Box>
 
-  ## The Nuke
+  ## A Bomba Nuclear
 
-  On your shuttle you will find one of two [color=#a4885c]Nuclear Fission Explosives[/color] and a paper with the nuke codes. The paper will tell you which explosive it corresponds to. If the ID is the same as the one on your nuke, the codes will only work for it. If it is not, then they will only work for the explosive in the station's vault.
+  Na sua nave, você encontrará um dos dois [color=#a4885c]Explosivos de Fissão Nuclear[/color] e um papel com os códigos da bomba nuclear. O papel informará a qual explosivo ele corresponde. Se a identificação for a mesma da sua bomba nuclear, os códigos funcionarão apenas para ela. Caso contrário, eles funcionarão apenas para o explosivo no cofre da estação.
 
-  Once you acquire the nuke disk, put it into the nuke and use the code to arm it. It takes 30 seconds for a crewmember to disarm it, and it will count down from 300. Be prepared to defend the nuke for as long as possible, remember that escaping alive isn't necessary, but recommended.
+  Depois de obter o disco nuclear, coloque-o na bomba nuclear e use o código para armá-la. Um membro da tripulação leva 30 segundos para desarmá-la, e a contagem regressiva começa em 300. Esteja preparado para defender a bomba nuclear o máximo de tempo possível. Lembre-se de que escapar vivo não é necessário, mas recomendado.
 
   <Box>
     <GuideEntityEmbed Entity="NuclearBomb" Caption="The Nuclear Fission Explosive"/>
   </Box>
 
-  ## Victories
+  ## Vitórias
 
-  The “victor” of the round is announced on the round end screen, as well as how much they won by. The scale of the victory depends on circumstances at the end of the round.
+  O "vencedor" da rodada é anunciado na tela de fim de rodada, assim como a diferença de diferença entre os dois. A magnitude da vitória depende das circunstâncias ao final da rodada.
 
-  [color=#a4885c]Syndicate Major Victory[/color]
-  - The nuke detonates on station
-  - The crew escapes on the evac shuttle, but the nuke was armed
-  - The nuke was armed and delivered to central command on the evac shuttle
+  [color=#a4885c]Vitória Maior do Sindicato[/color]
+  - A bomba nuclear detona na estação
+  - A tripulação escapa na nave de evacuação, mas a bomba nuclear estava armada
+  - A bomba nuclear foi armada e entregue ao comando central na nave de evacuação
 
-  [color=#a4885c]Syndicate Minor Victory[/color]
-  - The crew escapes on evac, but every nukie survives
-  - The crew escapes and some nukies die, but the crew loses the disk
+  [color=#a4885c]Vitória Menor do Sindicato[/color]
+  - A tripulação escapa na evacuação, mas todos os agentes nucleares sobrevivem
+  - A tripulação escapa e alguns agentes nucleares morrem, mas a tripulação perde o disco
 
-  [color=#a4885c]Neutral Victory[/color]
-  - The nuke detonates off station
+  [color=#a4885c]Vitória Neutra[/color]
+  - A bomba nuclear detona fora da estação
 
-  [color=#a4885c]Crew Minor Victory[/color]
-  - The crew escapes on evac and some nukies die, but the crew keeps the disk
+  [color=#a4885c]Vitória Menor da Tripulação[/color]
+  - A tripulação escapa na evacuação e alguns agentes nucleares morrem, mas a tripulação fica com o disco
 
-  [color=#a4885c]Crew Major Victory[/color]
-  - All nuclear operatives die
-  - The crew blow up the nukie outpost with the nuke
+  [color=#a4885c]Vitória Maior da Tripulação[/color]
+  - Todos os agentes nucleares morrem
+  - A tripulação explode O posto avançado de nukies com a bomba nuclear
 
-  If you feel that you won't be able to completely win as crew or nukie, consider these options for a compromise.
+  Se você acha que não conseguirá vencer completamente como tripulação ou nukie, considere estas opções para um meio-termo.
 </Document>
 
 

--- a/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
@@ -1,45 +1,45 @@
 <Document>
-  # Revolutionaries
+  # Revolucionários
 
-  - Revolutionaries are antagonists that are sponsored by the Syndicate to take over the station.
+  - Revolucionários são antagonistas patrocinados pelo Sindicato para assumir o controle da emissora.
 
-  ## Head Revolutionaries
+  ## Revolucionários Chefes
 
 <Box>
   <GuideEntityEmbed Entity="RevolutionaryManifesto" Caption="Revolutionary Manifesto"/>
 </Box>
 
-  [color=#5e9cff]Head Revolutionaries[/color] are chosen at the start of the shift and are tasked with taking over the station by killing, exiling or cuffing all of the Command staff. Head Revolutionaries will be given a [color=#a4885c]Revolutionary Manifesto[/color] to aid them.
+  Os [color=#5e9cff]Chefes Revolucionários[/color] são escolhidos no início do turno e têm a tarefa de tomar o controle da estação matando, exilando ou algemando toda a equipe do Comando. Os Chefes Revolucionários receberão um [color=#a4885c]Manifesto Revolucionário[/color] para ajudá-los.
 
-  ## Conversion
+  ## Conversão
 
   <Box>
   <GuideEntityEmbed Entity="RevolutionaryManifesto" Caption="Revolutionary Manifesto"/>
 </Box>
 
-  You can convert crew members by using a [color=#a4885c]Revolutionary Manifesto[/color] clicking someone with it.
+  Você pode converter membros da tripulação usando um [color=#a4885c]Manifesto Revolucionário[/color] clicando em alguém com ele.
 
 <Box>
   <GuideEntityEmbed Entity="MindShieldImplanter" Caption="MindShield Implanter"/>
 </Box>
 
-  Beware! A [color=#a4885c]MindShield Implant[/color] will prevent the implanted person from being converted into a revolutionary. Assume all of [color=#a4885c]Security[/color] and [color=#a4885c]Command[/color] are implanted already.
+  Cuidado! Um [color=#a4885c]Implante de Escudo Mental[/color] impedirá que a pessoa implantada se transforme em um revolucionário. Suponha que todos os membros da [color=#a4885c]Segurança[/color] e do [color=#a4885c]Comando[/color] já estejam implantados.
 
-  ## Revolutionary
+  ## Revolucionário
 
-  A [color=#ff0000]Revolutionary[/color] is the result of being converted by a [color=#5e9cff]Head Revolutionary[/color]. Revolutionaries are underlings of the Head Revolutionaries and should follow orders given by them and prioritize their well-being over anything else, because if they die, you will lose.
-  Keep in mind that you can't convert others as a regular revolutionary, only your boss can do that.
+  Um [color=#ff0000]Revolucionário[/color] é o resultado da conversão feita por um [color=#5e9cff]Chefe Revolucionário[/color]. Os revolucionários são subordinados dos Chefes Revolucionários e devem seguir as ordens deles e priorizar seu bem-estar acima de tudo, pois se eles morrerem, você perderá.
+  Lembre-se de que você não pode converter outros como um revolucionário comum; apenas seu chefe pode fazer isso.
 
-  ## Objectives
+  ## Objetivos
 
-  You must eliminate, exile or arrest all of the following Command staff on station in no particular order.
-  - Captain
-  - Head of Personnel
-  - Chief Engineer
-  - Mystagogue
-  - Logistics Officer
-  - Head of Security
-  - Chief Medical Officer
+  Você deve eliminar, exilar ou prender todos os seguintes membros do Comando na estação, sem nenhuma ordem específica.
+  - Capitão
+  - Chefe de Pessoal
+  - Engenheiro-Chefe
+  - Mistagogo
+  - Oficial de Logística
+  - Chefe de Segurança
+  - Diretor Médico
 
-  Remember, your objective is to take over the station and not to destroy it so try to minimize damage where possible. Viva la revolución!
+  Lembre-se, seu objetivo é tomar conta da estação e não destruí-la, então tente minimizar os danos sempre que possível. Viva la revolución!
 </Document>

--- a/Resources/ServerInfo/Guidebook/Antagonist/SpaceNinja.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/SpaceNinja.xml
@@ -1,80 +1,80 @@
 <Document>
-  # Space Ninja
+  # Ninja Espacial
 
-  The [color=#66FF00]Space Ninja[/color] is a ghost role randomly available mid-late game. If you pick it you will be given your gear, your objectives and the greeting.
+  O [color=#66FF00]Ninja Espacial[/color] é um papel fantasma disponível aleatoriamente no meio do jogo. Se você escolhê-lo, receberá seu equipamento, seus objetivos e a saudação.
 
-  You are a ninja, but in space. [color=#66FF00]The Spider Clan[/color] has sent you to the station to wreak all kinds of havoc, and you are equipped to keep it silent-but-deadly.
+  Você é um ninja, mas no espaço. O [color=#66FF00]Clã Aranha[/color] o enviou à estação para causar todo tipo de caos, e você está equipado para mantê-lo silencioso, porém mortal.
 
-  Whether you mercilessly pick off the station's crew one by one, or assassinate the clown over and over, your discipline has taught you that [color=#66FF00]your objectives must be at least attempted[/color]. For honor!
+  Quer você mate impiedosamente a tripulação da estação, um por um, ou assassine o palhaço repetidamente, sua disciplina lhe ensinou que [color=#66FF00]seus objetivos devem ser pelo menos alcançados[/color]. Por honra!
 
-  # Equipment
+  # Equipamento
 
-  You begin implanted with a [color=#a4885c]death acidifier[/color], so if you are KIA or decide to commit seppuku you will leave behind one final gift to the janitor and all your precious equipment is kept out of enemy hands.
+  Você começa implantado com um [color=#a4885c]acidificador da morte[/color], então, se você for morto em combate ou decidir cometer seppuku, deixará para trás um último presente para o zelador e todo o seu precioso equipamento será mantido longe das mãos inimigas.
 
-  Your bag is full of tools for more subtle sabotage, along with a survival box if you need a snack.
+  Sua bolsa está cheia de ferramentas para sabotagens mais sutis, além de uma caixa de sobrevivência caso precise de um lanche.
 
-  You have a [color=#a4885c]jetpack[/color] and [color=#a4885c]pinpointer[/color] that will let you find the station.
+  Você tem um [color=#a4885c]jetpack[/color] e um [color=#a4885c]pinpointer[/color] que permitirão que você encontre a estação.
 
   <GuideEntityEmbed Entity="PinpointerStation" Caption="station pinpointer"/>
 
-  ## Ninja Suit
+  ## Traje Ninja
 
   <GuideEntityEmbed Entity="ClothingOuterSuitSpaceNinja" Captain="ninja suit"/>
 
-  Your single most important item is [color=#66FF00]your suit[/color], without it none of your abilities would work.
-  Your suit requires power to function. Its [color=#a4885c]internal battery[/color] can be replaced by clicking on it with another one, and [color=#a4885c]higher capacity batteries[/color] mean a [color=#a4885c]highly effective ninja[/color].
-  You can see the current charge by examining the suit or in a sweet battery alert at the top right of your screen.
+  Seu item mais importante é [color=#66FF00]seu traje[/color], sem ele nenhuma de suas habilidades funcionaria.
+  Seu traje precisa de energia para funcionar. Sua [color=#a4885c]bateria interna[/color] pode ser substituída clicando nela por outra, e [color=#a4885c]baterias de maior capacidade[/color] significam um [color=#a4885c]ninja altamente eficaz[/color].
+  Você pode ver a carga atual examinando o traje ou em um alerta de bateria no canto superior direito da tela.
 
-  If you run out of power and need to recharge your battery, just use your gloves to drain an APC, substation or a SMES.
+  Se ficar sem energia e precisar recarregar a bateria, basta usar suas luvas para drenar um APC, uma subestação ou um SMES.
 
-  ## Ninja Gloves
+  ## Luvas Ninja
 
   <GuideEntityEmbed Entity="ClothingHandsGlovesSpaceNinja" Caption="ninja gloves"/>
 
-  [color=#66FF00]These bad boys are your bread and butter.[/color]
+  [color=#66FF00]Esses bad boys são o seu ganha-pão.[/color]
 
-  They are made from [color=#a4885c]insulated nanomachines[/color] to assist you in gracefully breaking and entering into your destination without leaving behind fingerprints.
+  Eles são feitos de [color=#a4885c]nanomáquinas isoladas[/color] para ajudá-lo a invadir seu destino com elegância, sem deixar impressões digitais.
 
-  You have an action to toggle gloves. When the gloves are turned on, they allow you to use [color=#a4885c]special abilities[/color], which are triggered by interacting with things with an empty hand and with combat mode disabled.
+  Você tem uma ação para ativar as luvas. Quando as luvas são ativadas, elas permitem que você use [color=#a4885c]habilidades especiais[/color], que são ativadas ao interagir com objetos com as mãos vazias e com o modo de combate desativado.
 
-  Your glove abilities include:
-  - Emagging an unlimited number of doors.
-  - Draining power from transformers such as APCs, substations or SMESes. The higher the voltage, the more efficient the draining is.
-  - You can shock any mob, stunning and slightly damaging them.
-  - You can download technologies from a R&D server for one of your objectives.
-  - You can hack a communications console to call in a threat.
+  As habilidades das suas luvas incluem:
+  - Gerar um número ilimitado de portas.
+  - Drenar energia de transformadores como APCs, subestações ou SMESes. Quanto maior a voltagem, mais eficiente é a drenagem.
+  - Você pode eletrocutar qualquer criatura, atordoando-a e causando-lhe danos leves.
+  - Você pode baixar tecnologias de um servidor de P&D para um de seus objetivos.
+  - Você pode hackear um console de comunicações para chamar uma ameaça.
 
-  ## Energy Katana
+  ## Katana de Energia
 
   <GuideEntityEmbed Entity="EnergyKatana" Captain="energy katana"/>
 
-  You have sworn yourself to the [color=#66FF00]sword[/color] and refuse to use firearms.
-  Deals a lot of damage and can be recalled at will, costing suit power proportional to the distance teleported.
-  
-  While in hand you can [color=#a4885c]teleport[/color] to anywhere that you can see, meaning most doors and windows, but not past solid walls.
-  This has a limited number of charges which regenerate slowly, so keep a charge or two spare incase you need a quick getaway.
+  Você jurou a si mesmo pela [color=#66FF00]espada[/color] e se recusa a usar armas de fogo.
+  Causa muito dano e pode ser revocada à vontade, custando poder de traje proporcional à distância teletransportada.
 
-  ## Spider Clan Charge
+  Enquanto estiver em mãos, você pode se [color=#a4885c]teletransportar[/color] para qualquer lugar à vista, ou seja, para a maioria das portas e janelas, mas não para além de paredes sólidas.
+  Esta tem um número limitado de cargas que se regeneram lentamente, então mantenha uma ou duas cargas sobrando caso precise de uma fuga rápida.
+
+  ## Carga do Clã Aranha
 
   <GuideEntityEmbed Entity="SpiderCharge" Caption="spider clan charge"/>
 
-  [color=#66FF00]A modified C-4 explosive[/color], you start with this in your pocket. Creates a large explosion but must be armed in your target area.
-  A random area on the map is selected for you to blow up, which is one of your [color=#a4885c]objectives[/color].
+  [color=#66FF00]Um explosivo C-4 modificado[/color], você começa com ele no bolso. Cria uma grande explosão, mas deve ser armado na sua área alvo.
+  Uma área aleatória no mapa é selecionada para você explodir, que é um dos seus [color=#a4885c]objetivos[/color].
 
-  It can't be activated manually, simply plant it on a wall or a particularly ugly piece of furniture.
-  Can't be unstuck once planted.
+  Não pode ser ativado manualmente, basta colocá-lo em uma parede ou em um móvel particularmente feio.
+  Não pode ser desenganchado depois de instalado.
 
-  ## Ninja Shoes
+  ## Sapatos Ninja
 
-  Special [color=#a4885c]noslips[/color] that keep you agile, swift and upright.
-  Energy not required.
+  [color=#a4885c]Picopatas[/color] especiais que o mantêm ágil, rápido e ereto.
+  Energia não requerida.
 
-  # Objectives
+  # Objetivos
 
-  - Download X research nodes: Use your gloves on an R&D server with a number of unlocked technologies
-  - Doorjack X doors on the station: Use your gloves to emag a number of doors.
-  - Detonate the spider clan charge: Plant your spider clan charge at a random location and watch it go boom.
-  - Call in a threat: Use your gloves on a communications console.
-  - Survive: Don't die.
+  - Baixar X nós de pesquisa: Use suas luvas em um servidor de P&D com diversas tecnologias desbloqueadas
+  - Arrombador de portas X portas na estação: Use suas luvas para explodir várias portas com emag.
+  - Detonar a carga do clã da aranha: Coloque sua carga do clã da aranha em um local aleatório e veja-a explodir.
+  - Avise sobre uma ameaça: use suas luvas em um console de comunicação.
+  - Sobreviva: não morra.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
@@ -1,74 +1,74 @@
 <Document>
-  # Traitors
+  # Traidores
 
-  - A Traitor is an antagonist employed by the Syndicate. They have access to various Syndicate tools and weapons through their [color=#a4885c]Uplink[/color].
-  - Traitors can use codewords to identify themselves to one another in order to cooperate.
-  - In a Traitor round, any player can be a Traitor aside from department heads, the captain, or any security officers.
-  - Traitors should focus primarily on completing their objectives successfully by the end of the round.
+  - Um Traidor é um antagonista empregado pelo Sindicato. Ele tem acesso a diversas ferramentas e armas do Sindicato por meio de seu [color=#a4885c]Uplink[/color].
+  - Traidores podem usar palavras-código para se identificarem uns aos outros e cooperarem.
+  - Em uma rodada de Traidores, qualquer jogador pode ser um Traidor, exceto chefes de departamento, o capitão ou quaisquer agentes de segurança.
+  - Traidores devem se concentrar principalmente em completar seus objetivos com sucesso até o final da rodada.
 
   ## Uplink
   <Box>
     <GuideEntityEmbed Entity="BaseUplinkRadio40TC" Caption="Uplink"/>
   </Box>
-  - The [color=#a4885c]Uplink[/color] is the most important tool as a Traitor, as it can purchase tools and weapons with [color=#a4885c]telecrystals[/color](TC).
+  - O [color=#a4885c]Uplink[/color] é a ferramenta mais importante para um Traidor, pois pode comprar ferramentas e armas com [color=#a4885c]telecristais[/color](TC).
   <Box>
     <GuideEntityEmbed Entity="Telecrystal" Caption="Telecrystals"/>
   </Box>
-  Traitors are antagonists employed by the [color=#ff0000]Syndicate.[/color] You are a sleeper agent who has access to various tools and weapons through your [bold]uplink[/bold].
-  You also receive [bold]codewords[/bold] to identify other agents, and a coordinated team of traitors can have [italic]brutal results.[/italic]
+  Traidores são antagonistas empregados pelo [color=#ff0000]Sindicato.[/color] Você é um agente adormecido que tem acesso a diversas ferramentas e armas por meio do seu [bold]uplink[/bold].
+  Você também recebe [bold]palavras-código[/bold] para identificar outros agentes, e uma equipe coordenada de traidores pode ter [italic]resultados brutais.[/italic]
 
-  Anyone besides [textlink="department heads" link="Command"] or members of [textlink="Security" link="Security"] can be a traitor.
+  Qualquer pessoa além de [textlink="chefes de departamento" link="Comando"] ou membros da [textlink="Segurança" link="Segurança"] pode ser um traidor.
 
-  ## Uplink & Activation
-  The [color=cyan]uplink[/color] is your most important tool as a traitor. You can exchange the 20 [color=red]telecrystals[/color] (TC) you start with for items that will help you with your objectives.
+  ## Uplink e Ativação
+  O [color=cyan]uplink[/color] é sua ferramenta mais importante como traidor. Você pode trocar os 20 [color=red]telecristais[/color] (TC) com os quais você começa por itens que o ajudarão em seus objetivos.
 
-  By pressing [color=yellow][bold][keybind="OpenCharacterMenu"][/bold][/color], you'll see your personal uplink code. [bold]Setting your PDA's ringtone as this code will open the uplink.[/bold]
-  Pressing [color=yellow][bold][keybind="OpenCharacterMenu"][/bold][/color] also lets you view your objectives and the codewords.
+  Ao pressionar [color=yellow][bold][keybind="OpenCharacterMenu"][/bold][/color], você verá seu código de uplink pessoal. [bold]Configurar o toque do seu PDA com este código abrirá o uplink.[/bold]
+  Pressionar [color=yellow][bold][keybind="OpenCharacterMenu"][/bold][/color] também permite que você visualize seus objetivos e as palavras-chave.
 
-  If you do not have a PDA when you are activated, an [color=cyan]uplink implant[/color] is provided [bold]for the full [color=red]TC[/color] price of the implant.[/bold]
-  It can be accessed from your hotbar.
+  Se você não tiver um PDA quando for ativado, um [color=cyan]implante de uplink[/color] será fornecido [bold]pelo preço total do [color=red]TC[/color] implante.[/bold]
+  Ele pode ser acessado na sua barra de atalhos.
   <Box>
     <GuideEntityEmbed Entity="PassengerPDA" Caption="PDA"/>
     <GuideEntityEmbed Entity="Telecrystal" Caption="Telecrystals"/>
     <GuideEntityEmbed Entity="BaseUplinkRadio" Caption="Uplink Implant"/>
   </Box>
 
-  [bold]Make sure to close your PDA uplink to prevent anyone else from seeing it.[/bold] You don't want [color=#cb0000]Security[/color] to get their hands on this premium selection of contraband!
+  [bold]Certifique-se de fechar o uplink do seu PDA para evitar que outras pessoas o vejam.[/bold] Você não quer que a [color=#cb0000]Segurança[/color] coloque as mãos nesta seleção premium de contrabando!
 
-  Implanted uplinks are not normally accessible to other people, so they do not have any security measures. They can, however, be removed from you with an empty implanter.
+  Uplinks implantados normalmente não são acessíveis a outras pessoas, portanto, não possuem nenhuma medida de segurança. No entanto, eles podem ser removidos de você com um implantador vazio.
 
   <Box>
     <GuideEntityEmbed Entity="Hypospray" Caption="CMO's Hypospray"/>
   </Box>
-  - Steal the Mystagogue's [color=#a4885c]Hardsuit[/color].
+  - Roube o [color=#a4885c]Hardsuit[/color] do Mistagogo.
   <Box>
     <GuideEntityEmbed Entity="ClothingOuterHardsuitRd" Caption="MG's Hardsuit"/>
   </Box>
-  - Steal the Mystagogue's [color=#a4885c]Hand Teleporter[/color].
+  - Roube o [color=#a4885c]Teletransportador de Mão[/color] do Mistagogo.
   <Box>
     <GuideEntityEmbed Entity="HandTeleporter" Caption="Hand Teleporter"/>
   </Box>
-  - Steal the Head of Security's [color=#a4885c]X-01 MultiPhase Energy Gun[/color].
+  - Roube a [color=#a4885c]Pistola de Energia Multifásica X-01[/color] do Chefe de Segurança.
   <Box>
     <GuideEntityEmbed Entity="WeaponEnergyGunMultiphase" Caption="Head of Security's personal Energy Gun"/>
   </Box>
-  - Steal the Chief Engineer's [color=#a4885c]Advanced Magboots[/color].
+  - Roube as [color=#a4885c]Botas Magnéticas Avançadas[/color] do Engenheiro-Chefe.
   <Box>
     <GuideEntityEmbed Entity="ClothingShoesBootsMagAdv" Caption="Advanced Magboots"/>
   </Box>
-  - Stealing the [color=#cb0000]Head of Security[/color]'s [bold]energy shotgun[/bold].
+  - Roubar a [bold]espingarda de energia[/bold] do [color=#cb0000]Chefe de Segurança[/color].
   <Box>
     <GuideEntityEmbed Entity="WeaponEnergyShotgun" Caption=""/>
   </Box>
-  - Steal the [color=#a4885c]Nuke Disk[/color].
+  - Roube o [color=#a4885c]Disco Nuclear[/color].
   <Box>
     <GuideEntityEmbed Entity="NukeDisk" Caption="Nuke Disk"/>
   </Box>
-  - Steal the Logistics Officer's [color=#a4885c]lucky bill[/color].
+  - Roube a [color=#a4885c]nota da sorte[/color] do Oficial de Logística.
   <Box>
     <GuideEntityEmbed Entity="SpaceCashLuckyBill" Caption="Logistics Officer's Lucky Bill"/>
   </Box>
-  - Steal the Head of Personnel's [color=#a4885c]Ian Photobook[/color].
+  - Roube o [color=#a4885c]Ian Photobook[/color] do Chefe de Pessoal.
   <Box>
     <GuideEntityEmbed Entity="BookIanDossier" Caption="Head of Personnel's Photobook"/>
   </Box>

--- a/Resources/ServerInfo/Guidebook/Antagonist/Zombies.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Zombies.xml
@@ -1,28 +1,28 @@
 <Document>
-  # Zombies
+  # Zumbis
 
   <Box>
     <GuideEntityEmbed Entity="SignBiohazard" Caption=""/>
   </Box>
 
-  - Zombies are antagonist that infect all beings that they bite.
+  - Zumbis são antagonistas que infectam todos os seres que mordem.
 
-  ## Infection
+  ## Infecção
 
-  - Three ways of getting infected are by starting out as the intial infected, being bitten by a zombified being, or being injected by [color=#a4885c]Romerol[/color].
+  - Três maneiras de se infectar: ​​começando como o infectado inicial, sendo mordido por um ser zumbificado ou sendo injetado por [color=#a4885c]Romerol[/color].
 
   <Box>
     <GuideReagentEmbed Reagent="Romerol"></GuideReagentEmbed>
   </Box>
 
-  ## Objectives
+  ## Objetivos
 
-  - The objective for zombies is to infect the entire station's crew.
+  - O objetivo dos zumbis é infectar toda a tripulação da estação.
 
-  ## Cure
+  ## Cura
 
-  - If you are already zombified, the only cure is death.
-  - If you are not zombified yet, using [color=#a4885c]Ambuzol[/color] will stop the infection from ensuing your timely demise but you may still get reinfected if not too careful. [color=#a4885c]Ambuzol Plus[/color] will prevent the infection continuously only while alive.
+  - Se você já estiver zumbificado, a única cura é a morte.
+  - Se você ainda não estiver zumbificado, usar [color=#a4885c]Ambuzol[/color] impedirá que a infecção cause sua morte prematura, mas você ainda poderá ser infectado novamente se não tomar muito cuidado. [color=#a4885c]Ambuzol Plus[/color] impedirá a infecção continuamente, apenas enquanto estiver vivo.
 
   <Box>
     <GuideReagentEmbed Reagent="Ambuzol"></GuideReagentEmbed>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentação**
	- Todo o conteúdo dos guias de antagonistas foi traduzido do inglês para o português brasileiro, incluindo descrições, instruções, objetivos e nomes de funções para todos os tipos de antagonistas (Antagonistas, Culto do Sangue, Antagonistas Menores, Operativos Nucleares, Revolucionários, Ninja Espacial, Traidores e Zumbis). Não houve alterações na estrutura ou funcionalidade dos documentos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->