### PR TITLE
Tradução da Aba de Medicina contida no Livro Guia

### DIFF
--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Biological.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Biological.xml
@@ -1,8 +1,8 @@
 <Document>
 
-# Biological
+  # Biológico
 
-These reagents include chemicals that you can get from certain materials and from living things. To get the other chemicals you have to use machines like the electrolyzer and the centrifuge.
+  Esses reagentes incluem substâncias químicas que podem ser obtidas de certos materiais e de seres vivos. Para obter as outras substâncias químicas, é necessário usar máquinas como o eletrolisador e a centrífuga.
 
 <GuideReagentGroupEmbed Group="Biological"/>
 

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Botany.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Botany.xml
@@ -1,8 +1,8 @@
 <Document>
 
-# Botanical Chemicals
+  # Produtos Químicos Botânicos
 
-These chemicals are used by botanists. Some of the chemicals change the properties of the plants.
+  Esses produtos químicos são usados por botânicos. Alguns deles alteram as propriedades das plantas.
 
 <GuideReagentEmbed Reagent="Ammonia"/>
 <GuideReagentEmbed Reagent="Diethylamine"/>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Elements.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Elements.xml
@@ -1,8 +1,8 @@
 <Document>
 
-# Elements
+  # Elementos
 
-This list contains all the basic reagents used to make other chemicals.
+  Esta lista contém todos os reagentes básicos usados para produzir outros produtos químicos.
 
 <GuideReagentGroupEmbed Group="Elements"/>
 

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Foods.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Foods.xml
@@ -1,7 +1,7 @@
 <Document>
-# Foods
+  # Alimentos
 
-These reagents are mostly used in the kitchen. Very helpful for Chefs and/or Service Workers.
+  Esses reagentes são usados principalmente na cozinha. Muito úteis para chefs e/ou prestadores de serviços.
 
 <GuideReagentGroupEmbed Group="Foods"/>
 

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Narcotics.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Narcotics.xml
@@ -1,5 +1,5 @@
 <Document>
-# Narcotics
-The reagents listed in this category includes stimulants, hallucinogens and other drug-like effects.
+  # Narcóticos
+  Os reagentes listados nesta categoria incluem estimulantes, alucinógenos e outros efeitos semelhantes aos de drogas.
 <GuideReagentGroupEmbed Group="Narcotics"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Other.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Other.xml
@@ -1,5 +1,5 @@
 <Document>
-# Other
-These are the other regeants listed in the Chemicals page.
+#Outros
+  Estes são os outros reagentes listados na página Produtos Químicos.
 <GuideReagentGroupEmbed Group="Unknown"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Pyrotechnic.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Pyrotechnic.xml
@@ -1,5 +1,5 @@
 <Document>
-# Pyrotechnics
-These chemicals are flammmable and causes hazardous effects when making them (Plasma gas and explosions). It is recommmended to make these chemicals in a safe environment.
+  # Pirotecnia
+  Esses produtos químicos são inflamáveis e causam efeitos perigosos durante sua fabricação (gás de plasma e explosões). Recomenda-se fabricá-los em um ambiente seguro.
 <GuideReagentGroupEmbed Group="Pyrotechnic"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Toxins.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Toxins.xml
@@ -1,5 +1,5 @@
 <Document>
-# Toxins
-The chemicals in this list contain toxins that induce certain effects and can cause death. Use responsibly.
+  # Toxinas
+  Os produtos químicos desta lista contêm toxinas que induzem certos efeitos e podem causar a morte. Use com responsabilidade.
 <GuideReagentGroupEmbed Group="Toxins"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/Chemicals.xml
+++ b/Resources/ServerInfo/Guidebook/Chemicals.xml
@@ -1,34 +1,34 @@
 ﻿<Document>
-# Chemicals
+  # Produtos Químicos
 
-Chemicals are a powerful tool that can cause a variety of effects when consumed. Some can be found in plants, purchased from logistics, or be synthesized through combination with other chemicals.
+  Produtos químicos são uma ferramenta poderosa que pode causar uma variedade de efeitos quando consumidos. Alguns podem ser encontrados em plantas, adquiridos de empresas de logística ou sintetizados por meio da combinação com outros produtos químicos.
 
-Knowing different types of chemicals and their effects is important for being able to manage injury and danger.
+  Conhecer os diferentes tipos de produtos químicos e seus efeitos é importante para poder lidar com lesões e perigos.
 
-## Elements
+  ## Elementos
 <GuideReagentGroupEmbed Group="Elements"/>
 
-## Medicine
-<GuideReagentGroupEmbed Group="Medicine"/>
+  ## Medicamentos
+  <GuideReagentGroupEmbed Group="Medicine"/>
 
-## Narcotics
-<GuideReagentGroupEmbed Group="Narcotics"/>
+  ## Narcóticos
+  <GuideReagentGroupEmbed Group="Narcóticos"/>
 
-## Pyrotechnics
+## Pirotecnia
 <GuideReagentGroupEmbed Group="Pyrotechnic"/>
 
-## Toxins
+## Toxinas
 <GuideReagentGroupEmbed Group="Toxins"/>
 
-## Foods
+## Alimentos
 <GuideReagentGroupEmbed Group="Foods"/>
 
-## Botanical
+## Botânicos
 <GuideReagentGroupEmbed Group="Botanical"/>
 
-## Biological
+## Biológicos
 <GuideReagentGroupEmbed Group="Biological"/>
 
-## Other
+## Outros
 <GuideReagentGroupEmbed Group="Unknown"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/Medical/AdvancedBrute.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/AdvancedBrute.xml
@@ -1,8 +1,8 @@
 <Document>
-  
-  # Specialized Brute Chemicals
 
-  Nanotrasen's greatest scientists have synthesized three more specific brute chemicals! Each one heals a specific damage subtype.
+  # Substâncias Químicas Brutas Especializadas
+
+  Os maiores cientistas de Nanotrasen sintetizaram mais três substâncias químicas brutas específicas! Cada uma cura um subtipo específico de dano.
 
   <GuideReagentEmbed Reagent="Bruizine"/>
   <GuideReagentEmbed Reagent="Puncturase"/>
@@ -10,19 +10,19 @@
 
   # Razorium
 
-  [color=red]USE CAUTION[/color] when using the aforementioned specialized brute chemicals. Should one mix together with a different type of brute chemical, the resulting mixture will create a dangerous chemical known as Razorium!
+  [color=red]TENHA CUIDADO[/color] ao usar os produtos químicos brutos especializados mencionados acima. Se um deles for misturado com um tipo diferente de produto químico bruto, a mistura resultante criará um produto químico perigoso conhecido como Razorium!
   <GuideReagentEmbed Reagent="Razorium"/>
-  To avoid this, make sure the patient is done metabolizing one brute medication before giving them another. Keep an eye on the rate their health is changing.
+  Para evitar isso, certifique-se de que o paciente tenha metabolizado um medicamento bruto antes de administrar outro. Fique de olho na velocidade com que sua saúde muda.
 
-  [bold]Some examples of mixtures that create Razorium are as follows:[/bold]
+  [bold]Alguns exemplos de misturas que criam Razorium são os seguintes:[/bold]
 
-  Bicaridine and Puncturase
+  Bicaridina e Punturase
 
-  Puncturase and Lacerinol
+  Punturase e Lacerinol
 
-  Bruizine and Bicaridine
+  Bruizina e Bicaridina
 
-  Lacerinol and Bruizine
+  Lacerinol e Bruizina
 
-  Please note that [bold]any[/bold] combination of these 4 chemicals will likely mix and create Razorium! Be careful when creating these chemicals, as they contain Bicaridine. Any leftover Bicaridine will likely mix to create Razorium!
+  Observe que [bold]qualquer[/bold] combinação desses 4 produtos químicos provavelmente se misturará e criará Razorium! Tenha cuidado ao criar esses produtos químicos, pois eles contêm Bicaridina. Qualquer sobra de Bicaridina provavelmente se misturará para criar Razorium!
 </Document>

--- a/Resources/ServerInfo/Guidebook/Medical/Botanicals.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Botanicals.xml
@@ -1,7 +1,7 @@
 <Document>
-# Botanicals
+  # Botânicos
 
-Botany and Chemistry can often work together to produce better medicine (or recreational cocktails). It may be worthwhile to give them the fertilizers they need, and request some medicinal plants in return.
+  Botânica e Química muitas vezes podem trabalhar juntas para produzir remédios melhores (ou coquetéis recreativos). Pode valer a pena dar a eles os fertilizantes de que precisam e pedir algumas plantas medicinais em troca.
 
 <Box>
 <GuideEntityEmbed Entity="FoodGalaxythistle"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Chemist.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Chemist.xml
@@ -1,10 +1,10 @@
 <Document>
-# Chemist
-Now you've done it, you picked the one job where -math- is mandatory. Grab your beaker, pull up a chair, and get cracking, it's time to cook up some chems.
+#Químico
+  Agora que você fez isso, escolheu o único trabalho em que -matemática- é obrigatória. Pegue seu béquer, puxe uma cadeira e mãos à obra, é hora de preparar alguns produtos químicos.
 
-While chemists primarily make medications, there's a very wide variety of chemicals that can be made, all of which are showcased in the Chemicals section of the Guidebook.
+  Embora os químicos produzam principalmente medicamentos, há uma grande variedade de produtos químicos que podem ser produzidos, todos apresentados na seção Produtos Químicos do Guia.
 
-## Equipment:
+  ## Equipamentos:
 
 <Box>
 <GuideEntityEmbed Entity="ChemDispenser"/>
@@ -20,25 +20,25 @@ While chemists primarily make medications, there's a very wide variety of chemic
 <GuideEntityEmbed Entity="PillCanister"/>
 </Box>
 
-## The Basics:
-Chemistry is fairly straightforward once you know what to expect. Here's a simple, step-by-step process on how to begin.
+  ## O Básico:
+  A química é bastante simples quando você sabe o que esperar. Aqui está um processo simples, passo a passo, de como começar.
 
-- Grab a beaker, Pill Canister, and if desired, some Bottles.
-- Place the beaker in the Chemical Dispenser, and Pill Canister (or bottle) in the Chem Master.
-- Open the Chemical Dispenser UI, and make your mix. Recipies are in other sections of the guidebook.
-- Alt-click the dispenser to remove your beaker, and place it in the Chem Master.
-- Open the Chem Master UI. On the Input tab, move your mix into the buffer.
-- Move to the Output tab, customise your pill, and press the Create button.
-- Alt-click the Chem Master to get the pill bottle out. You may have to remove the beaker first.
-- Click on a table, crate, or another surface to empty the pill bottle if desired. Alternatively, store or empty it into another storage container.
+  - Pegue um béquer, um recipiente para comprimidos e, se desejar, alguns frascos.
+  - Coloque o béquer no Dispensador de Produtos Químicos e o recipiente (ou frasco) para comprimidos no Mestre Químico.
+  - Abra a interface do Dispensador de Produtos Químicos e prepare sua mistura. As receitas estão em outras seções do guia.
+  - Clique com a tecla Alt pressionada no dispensador para remover o béquer e coloque-o no Mestre Químico.
+  - Abra a interface do Mestre Químico. Na aba Entrada, mova sua mistura para o reservatório.
+  - Vá para a aba Saída, personalize sua pílula e pressione o botão Criar.
+  - Clique com a tecla Alt pressionada no Mestre Químico para retirar o frasco de comprimidos. Pode ser necessário remover o béquer primeiro.
+  - Clique em uma mesa, caixa ou outra superfície para esvaziar o frasco de comprimidos, se desejar. Como alternativa, armazene ou esvazie-o em outro recipiente de armazenamento.
 
-That's it, you've made your first set of pills! Consider checking with Medical Doctors and other crew to see what else may be requested, refilling the medical kits in medbay storage, or just experimenting!
+  Pronto, você fez seu primeiro conjunto de pílulas! Considere consultar os médicos e outros membros da equipe para ver o que mais pode ser necessário, reabastecer os kits médicos no depósito da enfermaria ou simplesmente experimentar!
 
-You can also use the hand labeler to organize individual bottles or bags without using the Chem Master labeling system.
+  Você também pode usar o etiquetador manual para organizar frascos ou bolsas individuais sem usar o sistema de etiquetagem Chem Master.
 
-## Extra Content:
+  ## Conteúdo Extra:
 
-Speaking of experimentation, there are a few more toy you can use when it comes to chemistry. This job requires a lot of trial and error, but it was worth mentioning that these things exist! It's up to you to figure out what to make with them.
+  Falando em experimentação, existem mais alguns brinquedos que você pode usar quando se trata de química. Este trabalho requer muita tentativa e erro, mas vale a pena mencionar que essas coisas existem! Cabe a você descobrir o que fazer com elas.
 
 <Box>
 <GuideEntityEmbed Entity="ModularGrenade"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Cloning.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cloning.xml
@@ -1,20 +1,20 @@
 <Document>
-# Cloning
-If all else fails, patients will need to be cloned. This should only be used as a last resort, if recovery is impossible. This is most often the case when the body has started to rot, or if they have excessive amounts of damage.
+  # Clonagem
+  Se tudo mais falhar, os pacientes precisarão ser clonados. Isso só deve ser usado como último recurso, se a recuperação for impossível. Isso ocorre com mais frequência quando o corpo começa a apodrecer ou se apresenta danos excessivos.
 
-Cloning itself is relatively simple. (Assuming the network is set.) Just drag a body into the scanner, check the cloning console, and clone! If they've taken cellular damage, or have rotted for too long, the results can be... less than pleasant.
+  A clonagem em si é relativamente simples. (Supondo que a rede esteja configurada.) Basta arrastar um corpo para o scanner, verificar o console de clonagem e clonar! Se o corpo sofreu danos celulares ou apodreceu por muito tempo, os resultados podem ser... desagradáveis.
 
-As a note: Cloning isn't always available, and it would be best not to rely on it. Epistemics might be able to set up cloning, if it's unavailable.
+  Observação: a clonagem nem sempre está disponível e é melhor não depender dela. Epistêmicos podem conseguir configurar a clonagem, caso ela não esteja disponível.
 <Box>
 <GuideEntityEmbed Entity="ComputerCloningConsole" Caption="cloning console"/>
 <GuideEntityEmbed Entity="MedicalScanner"/>
 <GuideEntityEmbed Entity="CloningPod"/>
 <GuideEntityEmbed Entity="NetworkConfigurator"/>
 </Box>
-## Biomass
-Creating a clone requires biomass, which, gruesomely, involves recycling organic material. Be it crew members without a soul, station pets, or hostile creatures that have been 'taken care of', things can often be recycled.
+  ## Biomassa
+  Criar um clone requer biomassa, o que, horrivelmente, envolve a reciclagem de material orgânico. Sejam membros da tripulação sem alma, animais de estimação da estação ou criaturas hostis que foram "cuidadas", as coisas geralmente podem ser recicladas.
 
-Dragging a body onto the biomass reclaimer (with your cursor) will mulch it for re-use. If it's a crew member, it's common practice to strip the body and return departmental gear before doing such.
+  Arrastar um corpo para o recuperador de biomassa (com o cursor) o triturará para reutilização. Se for um membro da tripulação, é prática comum despir o corpo e devolver os equipamentos do departamento antes de fazer isso.
 <Box>
 <GuideEntityEmbed Entity="BiomassReclaimer"/>
 <GuideEntityEmbed Entity="MaterialBiomass"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -1,12 +1,12 @@
 <Document>
-# Cryogenics
-Cryogenics can be a bit daunting to understand, but hopefully, quick run through of this diagram, you'll learn how to work it! So, let's go over what each part does:
+  # Criogenia
+  A criogenia pode ser um pouco difícil de entender, mas espero que, com uma rápida olhada neste diagrama, você aprenda como funciona! Então, vamos ver o que cada parte faz:
 
-- Air in: Air comes in here through the distro or an air tank, giving those inside something to breathe, and the freezer something to chill.
-- Gas pump: Limits the network pressure, so those in the tube aren't crushed.
-- Freezer: Chills the air, and by extension, patients in the tube, so Cryoxadone can activate.
-- Gas filters: Removes waste gas (Carbon Dioxide and Nitrous Oxide) from the loop.
-- Air out: Waste gasses go here, either into a storage tank, or into the waste network.
+  - Entrada de ar: O ar entra aqui através do distribuidor ou de um tanque de ar, dando aos que estão dentro algo para respirar e ao freezer algo para resfriar.
+  - Bomba de gás: Limita a pressão da rede, para que os que estão no tubo não sejam esmagados.
+  - Freezer: Resfria o ar e, por extensão, os pacientes no tubo, para que a Crioxadona possa ser ativada.
+  - Filtros de gás: Removem os gases residuais (Dióxido de Carbono e Óxido Nitroso) do circuito.
+  - Saída de ar: Os gases residuais vão para aqui, para um tanque de armazenamento ou para a rede de resíduos.
 <Box>
 <GuideEntityEmbed Entity="GasPipeBend" Rotation="90"/>
 <GuideEntityEmbed Entity="GasPipeStraight" Rotation="90"/>
@@ -32,16 +32,16 @@ Cryogenics can be a bit daunting to understand, but hopefully, quick run through
 <GuideEntityEmbed Entity="GasPipeBend" Rotation="270"/>
 </Box>
 
-Not every network will look like this, but hopefully, it's enough to give you the basic gist of how it's functioning.
+  Nem todas as redes terão esta aparência, mas esperamos que seja o suficiente para lhe dar uma ideia básica de como elas funcionam.
 
-An important thing to note, winter clothing (and hardsuits) will make cryogenic treatment less, or completely ineffective. Be sure to remove cold preventative clothing before placing people in the pod.
+  Um ponto importante a ser observado é que roupas de inverno (e trajes rígidos) tornarão o tratamento criogênico menos eficaz ou até mesmo completamente ineficaz. Certifique-se de remover as roupas de proteção contra o frio antes de colocar as pessoas na cápsula.
 
-## Using the Pod
-Once things have been set up, you're going to require a specific medication, Cryoxadone. Cryoxadone heals all damage types when a patient is chilled, and can either be pre-adminsitered (with a pill), or loaded into the cell directly with a beaker. Do note, patients won't begin to heal until they've chilled to the appropriate temperature, it may be worthwhile to wait a bit before placing a beaker inside.
+  ## Usando a Cápsula
+  Depois de tudo configurado, você precisará de um medicamento específico, a Crioxadona. A Crioxadona cura todos os tipos de danos quando o paciente é resfriado e pode ser pré-administrada (com um comprimido) ou aplicada diretamente na célula com um béquer. Observe que os pacientes não começarão a se recuperar até que estejam resfriados à temperatura adequada; pode valer a pena esperar um pouco antes de colocar um béquer dentro da célula.
 
-## Additional Information:
+  ## Informações adicionais:
 
-The standard pressure for a gas pump is 100.325 kpa. Cryoxadone works at under 170K, but it is standard practice to set the freezer to 100K for faster freezing.
+  A pressão padrão de uma bomba de gás é de 100,325 kPa. A crioxadona funciona em temperaturas abaixo de 170K, mas é prática padrão ajustar o freezer para 100K para congelamento mais rápido.
 
 <GuideReagentEmbed Reagent="Cryoxadone"/>
 <GuideReagentEmbed Reagent="Doxarubixadone"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Medical.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Medical.xml
@@ -1,10 +1,10 @@
 <Document>
-# Medical
-This is the department where people go to when they're hurt, it's up to the folks working here to fix them.
+  # Médico
+  Este é o departamento para onde as pessoas vão quando se machucam; cabe às pessoas que trabalham aqui curá-las.
 
-Right now, medbay is divided into two different sets of care:
+  Atualmente, o Medbay está dividido em dois conjuntos de cuidados diferentes:
 
-## Medical Treatment
+  ## Tratamento Médico
 <Box>
 <GuideEntityEmbed Entity="Brutepack"/>
 <GuideEntityEmbed Entity="Bloodpack"/>
@@ -12,7 +12,7 @@ Right now, medbay is divided into two different sets of care:
 <GuideEntityEmbed Entity="Gauze"/>
 <GuideEntityEmbed Entity="HandheldHealthAnalyzer"/>
 </Box>
-## Chemical Production
+  ## Produção Química
 <Box>
 <GuideEntityEmbed Entity="ChemDispenser"/>
 <GuideEntityEmbed Entity="LargeBeaker"/>

--- a/Resources/ServerInfo/Guidebook/Medical/MedicalDoctor.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/MedicalDoctor.xml
@@ -1,13 +1,13 @@
 <Document>
-# Medical Doctor
-It's time to heal. Or at least, try to heal, anyway. Medical Doctors are the primary caretakers of every boo boo and ouchie crewmembers get on the station, be it a small scratch, or boiled skin.
+  # Médico
+  É hora de se curar. Ou pelo menos tentar se curar, pelo menos. Médicos são os principais responsáveis ​​por cada machucado e dor que os tripulantes recebem na estação, seja um pequeno arranhão ou pele queimada.
 
-This guide will give you a basic outline of the treatment options you have available, triage, and other avenues of care.
+  Este guia fornecerá um esboço básico das opções de tratamento disponíveis, triagem e outras formas de cuidado.
 
-## The Basics
-There are two ways to tell what's ailing someone: Taking a scan (with a health analyzer or a medical PDA), or examining them, with a shift-click, and clicking the heart symbol.
+  ## O Básico
+  Há duas maneiras de saber o que está acontecendo com alguém: fazendo uma varredura (com um analisador de saúde ou um PDA médico) ou examinando a pessoa, pressionando Shift e clicando no símbolo de coração.
 
-It's best to do both, if possible, as some things (such as poison, or radiation) don't show up on examination, while others (such as blood levels) don't show up on an analyzer.
+  É melhor fazer as duas coisas, se possível, pois algumas coisas (como veneno ou radiação) não aparecem no exame, enquanto outras (como níveis sanguíneos) não aparecem no analisador.
 <Box>
 <GuideEntityEmbed Entity="SignExamroom" Caption="examine patient"/>
 <GuideEntityEmbed Entity="MedicalPDA"/>
@@ -15,20 +15,20 @@ It's best to do both, if possible, as some things (such as poison, or radiation)
 <GuideEntityEmbed Entity="HandheldHealthAnalyzer"/>
 </Box>
 
-## Medication and Treatment Options
-Before we go any further, it's probably a good idea to go over damage types, and what will heal them The wiki has more extensive info available, but these are commonly used.
+  ## Medicamentos e Opções de Tratamento
+  Antes de prosseguirmos, provavelmente é uma boa ideia analisar os tipos de dano e o que pode curá-los. O wiki tem informações mais abrangentes disponíveis, mas estas são as mais utilizadas.
 
-An important note: Most medication has an overdose level, which will cause harm to your patient. Chemicals also take time to metabolise in pill form, if you want things to act quickly, use a syringe.
+  Uma observação importante: a maioria dos medicamentos tem um nível de overdose, o que causará danos ao seu paciente. Os produtos químicos também levam tempo para serem metabolizados na forma de comprimidos; se quiser que os efeitos sejam rápidos, use uma seringa.
 
-- Brute Damage: Bicaridine or Bruise Packs
-- Burn Damage: Dermaline or Ointment
-- Toxin (Poison): Dylovene
-- Toxin (Radiation) Hyronalin or Arithrazine
-- Airloss: Dexaline or Inaprovaline
-- Bloodloss: Dexaline (Examine the patient, if pale, they still need blood or iron.)
-- Bleeding: Tranexamic acid and Gauze (Bleeding can also be cauterized with burn damage.)
+  - Dano Bruto: Bicaridina ou Compressas para Contusões
+  - Dano por Queimadura: Dermaline ou Pomada
+  - Toxina (Veneno): Dilovene
+  - Toxina (Radiação) Hyronalin ou Arithrazine
+  - Perda de Ar: Dexaline ou Inaprovaline
+  - Perda de Sangue: Dexaline (Examine o paciente; se estiver pálido, ele ainda precisa de sangue ou ferro.)
+  - Sangramento: Ácido Tranexâmico e Gaze (O sangramento também pode ser cauterizado em caso de queimadura.)
 
-Many stations are stocked with kits in storage, and all medics have some equipment in their starting belt.
+  Muitas estações possuem kits armazenados, e todos os médicos têm algum equipamento em seus cintos de partida.
 
 <Box>
 <GuideEntityEmbed Entity="MedkitFilled"/>
@@ -46,24 +46,24 @@ Many stations are stocked with kits in storage, and all medics have some equipme
 <GuideEntityEmbed Entity="Gauze"/>
 </Box>
 
-## Basic Treatment and Triage
-Examine your patient, and note down the important details: Are they alive? Bleeding? What type of damage?
+  ## Tratamento Básico e Triagem
+  Examine seu paciente e anote os detalhes importantes: Ele está vivo? Sangrando? Que tipo de dano?
 
-If alive, treat them as best as you can. Patients are in critical condition at 100 damage, and dead at 200. Keep this in mind when choosing how to treat them. Emergency Pens and Epinephrine are often used to keep patients stable.
+  Se estiver vivo, trate-o da melhor maneira possível. Os pacientes estão em estado crítico com 100 de dano e mortos com 200. Tenha isso em mente ao escolher como tratá-los. Canetas de Emergência e Epinefrina são frequentemente usadas para manter os pacientes estáveis.
 
-If possible, buckle them to a medical bed, if you need time to treat them, strap them to a stasis bed instead. Just keep in mind that metabolism (and by extension, healing chemicals) are slowed to a crawl when on stasis, they'll need to be taken off of it for the medicine to be effective. (But Blood Packs, Ointment, and Brute packs all work as normal.)
+  Se possível, prenda-os a uma cama médica; se precisar de tempo para tratá-los, prenda-os a uma cama de estase. Lembre-se apenas de que o metabolismo (e, por extensão, os produtos químicos de cura) ficam muito lentos durante a estase; eles precisarão ser retirados dela para que o medicamento faça efeito. (Mas Bolsas de Sangue, Pomada e Bolsas Brutas funcionam normalmente.)
 <Box>
 <GuideEntityEmbed Entity="MedicalBed"/>
 <GuideEntityEmbed Entity="StasisBed"/>
 </Box>
-## Death and Revival
-You can't save them all, sometimes, death happens. Depending on the status of the body, if there's a soul present, and if the body has started rotting, there are a few things that can be done.
+  ## Morte e Renascimento
+  Você não pode salvar todos; às vezes, a morte acontece. Dependendo do estado do corpo, se houver uma alma presente e se o corpo tiver começado a apodrecer, há algumas coisas que podem ser feitas.
 
-1. Do they have a soul attached? You can tell if, when examining, the following phrase is displayed: "Their soul has departed." If this isn't displayed, consider storing the body in a morgue tray, or using them for biomass.
+  1. Eles têm uma alma anexada? Você pode dizer se, ao examiná-los, a seguinte frase for exibida: "A alma deles partiu". Se isso não for exibido, considere armazenar o corpo em uma bandeja de necrotério ou usá-lo como biomassa.
 
-2. Is the body rotting? If it is, sadly, they'll have to be cloned. A rotting body can't be brought back with a defibrillator. (See Cloning)
+  2. O corpo está apodrecendo? Se estiver, infelizmente, eles terão que ser clonados. Um corpo em decomposição não pode ser trazido de volta com um desfibrilador. (Veja Clonagem)
 
-3. If they have a soul, and aren't rotten, it's possible to revive them. Not counting airloss, Defibrillator's can be used to revive patients under 200 total damage. Chemicals don't metabolise in the dead, but brute packs and ointment can still patch them up. Use them to bring their numbers down enough for revival.
+  3. Se eles tiverem uma alma e não estiverem apodrecidos, é possível revivê-los. Sem contar a perda de ar, desfibriladores podem ser usados para reviver pacientes com menos de 200 de dano total. Produtos químicos não são metabolizados nos mortos, mas compressas brutas e pomadas ainda podem curá-los. Use-os para reduzir seus números o suficiente para a revitalização.
 
 <Box>
 <GuideEntityEmbed Entity="Brutepack"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Medicine.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Medicine.xml
@@ -1,8 +1,8 @@
 <Document>
 
-# Core Medications
+  # Medicamentos Essenciais
 
-These medications are almost always useful to medbay in one way or another.
+  Esses medicamentos são quase sempre úteis para o Medbay de uma forma ou de outra.
 
 <GuideReagentEmbed Reagent="Bicaridine"/>
 <GuideReagentEmbed Reagent="Kelotane"/>
@@ -13,9 +13,9 @@ These medications are almost always useful to medbay in one way or another.
 <GuideReagentEmbed Reagent="DexalinPlus"/>
 <GuideReagentEmbed Reagent="Iron"/>
 
-# Specialty Medications
+  # Medicamentos Especiais
 
-These medications tend to have specific use cases.
+  Esses medicamentos tendem a ter casos de uso específicos.
 
 <GuideReagentEmbed Reagent="Cryoxadone"/>
 <GuideReagentEmbed Reagent="Epinephrine"/>

--- a/Resources/ServerInfo/_Shitmed/Guidebook/Medical/Autodoc.xml
+++ b/Resources/ServerInfo/_Shitmed/Guidebook/Medical/Autodoc.xml
@@ -1,42 +1,42 @@
 <Document>
-# Autodoc Mk.XIV
+  # Autodoc Mk.XIV
 
-With designs rescued from the derelict KC13, this powerhouse of a mechanical surgeon can be programmed to do just about anything.
+  Com projetos resgatados do KC13 abandonado, este poderoso cirurgião mecânico pode ser programado para fazer praticamente qualquer coisa.
 
-WARNING: Operation of this device requires proper medical certification and adherence to established medical protocols.
+  AVISO: A operação deste dispositivo requer certificação médica adequada e adesão aos protocolos médicos estabelecidos.
 
-To get started, use a multitool to link it to a nearby operating table, once it detects a patient sleeping on it, you are ready to operate!
+  Para começar, use uma ferramenta multifuncional para conectá-lo a uma mesa cirúrgica próxima. Assim que detectar um paciente dormindo sobre ela, você estará pronto para operar!
 
-Before operating put any items a program needs in its storage trays. The Autodoc cannot pick up items off your dirty, blood-stained floor.
+  Antes de operar, coloque todos os itens necessários para o programa em suas bandejas de armazenamento. O Autodoc não consegue coletar itens do seu chão sujo e manchado de sangue.
 
-# How I make it do the thing help
+  # Como eu o faço funcionar ajuda
 
-An autodoc unit has a list of programs, which have steps that are completed in order until the program is complete.
+  Uma unidade Autodoc possui uma lista de programas, com etapas que são concluídas em ordem até que o programa seja concluído.
 
-Should any issues arise during these steps, it will immediately abort the procedure, unless the program has safety disabled.
+  Caso surja algum problema durante essas etapas, o procedimento será imediatamente abortado, a menos que o programa tenha a segurança desativada.
 
-To get started, create a new program with a memorable name, such as "organ stealy". Hit "ADD STEP" to add different kinds of steps:
-- PERFORM SURGERY, the beast itself. Can target any bodypart and complete any surgery. It is up to the programmer to ensure that compatible surgeries are selected, it's a bad idea to install a brain in someones feet.
-  You do not need to add prerequesites like opening the ribcage, they are automatically done.
-- GRAB ITEM, this will look in its item trays for an item with that exact name and grab it for use in surgeries. Use a hand labeler to distinguish multiple of the same item.
-- GRAB ORGAN, this is a shorthand to grab any kind of organ.
-- GRAB PART, this is a shorthand to grab any kind of bodypart.
-- STORE ITEM, this puts the held item in the item trays (if they aren't full). You have to do this after removing an item from the patient, or future operations will get dropped on the floor!
-- SET LABEL, gives the held item a short label. Extremely useful for organ transplants, where specific a organ is needed.
-- WAIT, this just waits a length of time before continuing.
+  Para começar, crie um novo programa com um nome fácil de lembrar, como "roubo de órgãos". Clique em "ADICIONAR ETAPA" para adicionar diferentes tipos de etapas:
+  - REALIZAR CIRURGIA, a fera em si. Pode atingir qualquer parte do corpo e concluir qualquer cirurgia. Cabe ao programador garantir que cirurgias compatíveis sejam selecionadas; é uma má ideia instalar um cérebro nos pés de alguém.
+  Você não precisa adicionar pré-requisitos como abrir a caixa torácica, eles são feitos automaticamente.
+  - PEGAR ITEM, isso procurará em suas bandejas de itens por um item com esse nome exato e o pegará para uso em cirurgias. Use um etiquetador manual para distinguir vários itens iguais.
+  - PEGAR ÓRGÃO, isso é uma abreviação para pegar qualquer tipo de órgão.
+  - PEGAR PARTE, isso é uma abreviação para pegar qualquer tipo de parte do corpo.
+  - ARMAZENAR ITEM, isso coloca o item retido nas bandejas de itens (se elas não estiverem cheias). Você precisa fazer isso após remover um item do paciente, ou futuras operações serão descartadas!
+  - DEFINIR ETIQUETA, dá ao item retido uma etiqueta curta. Extremamente útil para transplantes de órgãos, onde um órgão específico é necessário.
+  - ESPERE, isso só espera um pouco antes de continuar.
 
-So what are you waiting for comrade? Commit war crimes today!
+  Então, o que você está esperando, camarada? Cometa crimes de guerra hoje mesmo!
 
-# Additional program usage
+  # Uso adicional do programa
 
-- Disabling a program's safety makes it skip failed steps instead of aborting the entire program.
-  Only do this if you know what you are doing!
-- Selecting a step lets you remove it or add a new step before it, instead of always inserting at the end.
+  - Desativar a segurança de um programa faz com que ele pule etapas com falha em vez de abortar o programa inteiro.
+  Só faça isso se souber o que está fazendo!
+  - Selecionar uma etapa permite removê-la ou adicionar uma nova etapa antes dela, em vez de sempre inserir no final.
 
-# Caveats
+  # Advertências
 
-- Do not under any circumstances snip the machines SAFETY wire, automated personnel medical license would be void.
-  Anesthesia is REQUIRED for safe operation and disabling the need for it is highly unethical to patients.
-- Amputating legs or arms will detach their feet and hands to the floor. Manual intervention will be required, so cut them off first if you need them.
-- If the storage trays are filled, storing items will be impossible and the device will essentially seize up.
+  - Em nenhuma circunstância corte o fio de SEGURANÇA da máquina; a licença médica do pessoal automatizado será anulada.
+  A anestesia é NECESSÁRIA para uma operação segura e desativar a necessidade dela é altamente antiético para os pacientes.
+  - Amputar pernas ou braços fará com que seus pés e mãos se soltem do chão. Será necessária intervenção manual, portanto, corte-os primeiro, se necessário.
+  - Se as bandejas de armazenamento estiverem cheias, o armazenamento de itens será impossível e o dispositivo basicamente travará.
 </Document>

--- a/Resources/ServerInfo/_Shitmed/Guidebook/Medical/OrganManipulation.xml
+++ b/Resources/ServerInfo/_Shitmed/Guidebook/Medical/OrganManipulation.xml
@@ -1,9 +1,9 @@
 <Document>
-# Organ Manipulation
-These surgeries allow you to remove or replace organs from a patient for healthy ones. Which can help treat conditions on their bodies.
+  # Manipulação de Órgãos
+  Essas cirurgias permitem remover ou substituir órgãos de um paciente por outros saudáveis, o que pode ajudar a tratar condições em seus corpos.
 
-## Anatomy
-Normally a body has the following organs:
+  ## Anatomia
+  Normalmente, um corpo possui os seguintes órgãos:
 
 <Box>
 <GuideEntityEmbed Entity="OrganHumanBrain" Caption="brain"/>
@@ -17,23 +17,24 @@ Normally a body has the following organs:
 <GuideEntityEmbed Entity="OrganHumanStomach" Caption="stomach"/>
 </Box>
 
-Certain species might have more or less organs, such as Diona having a combined organ that serves multiple functions, but this is the rough outline of what you'll see.
-To remove an organ, you'll need to apply the respective Organ Removal surgery on it, which will then remove it without harming the patient.
+  Certas espécies podem ter mais ou menos órgãos, como Diona, que possui um órgão combinado com múltiplas funções, mas este é um esboço do que você verá.
+  Para remover um órgão, você precisará aplicar a respectiva cirurgia de Remoção de Órgãos, que o removerá sem causar danos ao paciente.
 
-However if you want to transplant an organ, you'll need to apply the respective Organ Transplant surgery where it originally was.
+  No entanto, se você quiser transplantar um órgão, precisará aplicar a respectiva cirurgia de Transplante de Órgãos onde ele estava originalmente.
 
-## What does each organ transplant do?
+  ## O que cada transplante de órgão faz?
 
-- Transplanting a [color=#a4885c]brain[/color] will allow the patient to take over another body. An excellent alternative to cloning if you can afford to spare another body.
-- Transplanting a [color=#a4885c]liver[/color] will cure severe poisoning from a patient's body.
-- Transplanting [color=#a4885c]lungs[/color] will help cure patients from severe asphyxiation.
-- Transplanting a [color=#a4885c]heart[/color] will cure a patient's body of rot and decay.
-- Transplanting [color=#a4885c]eyes[/color] will allow the patient to see again, and heal any eye damage.
+  - Transplantar um [color=#a4885c]cérebro[/color] permitirá que o paciente assuma outro corpo. Uma excelente alternativa à clonagem se você puder poupar outro corpo.
+  - Transplantar um [color=#a4885c]fígado[/color] curará um envenenamento grave do corpo de um paciente.
+  - Transplantar [color=#a4885c]pulmões[/color] ajudará a curar pacientes de asfixia grave.
 
-## Where do I get more organs?
+  - Transplantar um [color=#a4885c]coração[/color] curará a podridão e a decomposição do corpo do paciente.
+  - Transplantar [color=#a4885c]olhos[/color] permitirá que o paciente enxergue novamente e cure qualquer dano ocular.
 
-Normally when your patients come in needing new organs, they'll need to get a new one, as their old ones will be either missing, or damaged beyond repair.
-For this you can use the Medical Biofabricator with some Biomass. Which can manufacture Biosynthetic organs for all species.
+  ## Onde consigo mais órgãos?
+
+  Normalmente, quando seus pacientes chegam precisando de novos órgãos, eles precisam obter um novo, pois os antigos estarão ausentes ou danificados irreparavelmente.
+  Para isso, você pode usar o Biofabricador Médico com um pouco de Biomassa, que pode fabricar órgãos biossintéticos para todas as espécies.
 
 <Box>
 <GuideEntityEmbed Entity="MedicalBiofabricator" Caption="medical biofabricator"/>
@@ -41,11 +42,11 @@ For this you can use the Medical Biofabricator with some Biomass. Which can manu
 <GuideEntityEmbed Entity="MaterialBiomass" Caption="biomass"/>
 </Box>
 
-By default, every Chief Medical Officer has access to a Medical Biofabricator board in their locker.
+  Por padrão, todo Diretor Médico tem acesso a um quadro de Biofabricador Médico em seu armário.
 
-## Why didn't the organ transplant
-## do anything?
+  ## Por que o transplante de órgão
+  ## não fez nada?
 
-Your patient's body rejected the organ as it is in a bad shape, try using a fresh organ from a donor, or getting a new one from the Medical Biofabricator.
+  O corpo do seu paciente rejeitou o órgão por estar em mau estado. Tente usar um órgão fresco de um doador ou obter um novo do Biofabricador Médico.
 
 </Document>

--- a/Resources/ServerInfo/_Shitmed/Guidebook/Medical/PartManipulation.xml
+++ b/Resources/ServerInfo/_Shitmed/Guidebook/Medical/PartManipulation.xml
@@ -1,9 +1,9 @@
 <Document>
-# Part Manipulation
-This is how you will turn felinids into humans, or vice versa if you're feeling particularly cruel.
+  # Manipulação de Partes
+  É assim que você transformará felinos em humanos, ou vice-versa, se estiver se sentindo particularmente cruel.
 
-## Anatomy
-Normally a body has 10 main parts. Those being:
+  ## Anatomia
+  Normalmente, um corpo tem 10 partes principais. São elas:
 
 <Box>
 <GuideEntityEmbed Entity="HeadHuman" Caption="head"/>
@@ -22,17 +22,16 @@ Normally a body has 10 main parts. Those being:
 <GuideEntityEmbed Entity="LeftFootHuman" Caption="left foot"/>
 </Box>
 
-Certain species might have more or less parts, such as tails, wings, or extra limbs, but this is the rough outline of what you'll see.
-To detach a limb, you'll need to apply the Remove Part surgery on it, which will then remove it without harming the patient.
+  Certas espécies podem ter mais ou menos partes, como caudas, asas ou membros extras, mas este é um esboço do que você verá.
+  Para desmembrar um membro, você precisará aplicar a cirurgia de Remover Partes, que o removerá sem causar danos ao paciente.
 
-However if you want to reattach the limb, you'll need to apply the Attach Part surgery where you want it attached.
-Hands are attached to the arms, feet are attached to the legs. And everything else is attached to the torso.
+  No entanto, se você quiser recolocar o membro, precisará aplicar a cirurgia de Anexar Partes no local onde deseja fixá-lo.
+  As mãos são fixadas aos braços, os pés às pernas. E todo o resto é fixado ao tronco.
 
+  ## Onde consigo mais partes?
 
-## Where do I get more parts?
-
-Normally when your patients come in needing new limbs, they'll need to get a new one, as their old ones will be either missing, or damaged beyond repair.
-For this you can use the Medical Biofabricator with some Biomass. Which can manufacture Biosynthetic limbs for all species.
+  Normalmente, quando seus pacientes chegam precisando de novos membros, eles precisam obter um novo, pois os antigos estarão faltando ou danificados sem possibilidade de reparo.
+  Para isso, você pode usar o Biofabricador Médico com um pouco de Biomassa, que pode fabricar membros biossintéticos para todas as espécies.
 
 <Box>
 <GuideEntityEmbed Entity="MedicalBiofabricator" Caption="medical biofabricator"/>
@@ -40,12 +39,12 @@ For this you can use the Medical Biofabricator with some Biomass. Which can manu
 <GuideEntityEmbed Entity="MaterialBiomass" Caption="biomass"/>
 </Box>
 
-By default, every Chief Medical Officer has access to a Medical Biofabricator board in their locker.
+BPor padrão, todo Diretor Médico tem acesso a um tabuleiro de Biofabricante Médico em seu armário.
 
-## I reattached my patient's limb, but
-## it's not working?
+  ## Reimplantei o membro do meu paciente, mas
+  ## não está funcionando?
 
-Your patient has taken enough damage to the point that their limb's nerves were badly damaged, and they need to be healed properly before it can work again.
-For this you can try the Tend Wounds surgeries, or letting them use topicals on their wounds.
+  Seu paciente sofreu danos suficientes a ponto de os nervos do membro estarem gravemente danificados e precisa ser curado adequadamente antes que possa funcionar novamente.
+  Para isso, você pode tentar as cirurgias de Tratamento de Feridas ou permitir que ele use tópicos nos ferimentos.
 
 </Document>

--- a/Resources/ServerInfo/_Shitmed/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/_Shitmed/Guidebook/Medical/Surgery.xml
@@ -1,27 +1,27 @@
 <Document>
-# Surgery
-Your usual weekly activity. By performing surgical operations on your patients, you can heal wounds, remove or add body parts, organs, and more.
+  # Cirurgia
+  Sua atividade semanal habitual. Ao realizar operações cirúrgicas em seus pacientes, você pode curar feridas, remover ou adicionar partes do corpo, órgãos e muito mais.
 
-## The Basics
-To start surgery your patient needs to be laying down, and ideally sedated.
+  ## Noções básicas
+  Para iniciar a cirurgia, seu paciente precisa estar deitado e, idealmente, sedado.
 
-If they are not sedated, they will be in a lot of pain, which decreases their mood, and will make surgical wounds worse.
+  Se não estiver sedado, sentirá muita dor, o que diminui seu humor e piora as feridas cirúrgicas.
 
 <Box>
 <GuideEntityEmbed Entity="NitrousOxideTank" Caption="nitrous oxide"/>
 <GuideEntityEmbed Entity="ClothingMaskBreathMedical" Caption="any breathing tool"/>
 </Box>
 
-You also need to wear protective gear such as a mask and gloves to prevent harming the patient due to contamination.
+  Você também precisa usar equipamentos de proteção, como máscara e luvas, para evitar danos ao paciente devido à contaminação.
 
 <Box>
 <GuideEntityEmbed Entity="ClothingMaskSterile" Caption="any mask"/>
 <GuideEntityEmbed Entity="ClothingHandsGlovesNitrile" Caption="any gloves"/>
 </Box>
 
-## Getting Started
+  ## Começando
 
-To engage in surgery, you'll need a set of surgical tools.
+  Para realizar uma cirurgia, você precisará de um conjunto de instrumentos cirúrgicos.
 
 <Box>
 <GuideEntityEmbed Entity="Scalpel" Caption="scalpel"/>
@@ -35,11 +35,11 @@ To engage in surgery, you'll need a set of surgical tools.
 <GuideEntityEmbed Entity="BoneGel" Caption="bone gel"/>
 </Box>
 
-Once you've got tools in hand, interact with your patient to begin surgery. You'll be able to choose which part you want to operate on.
+  Depois de ter as ferramentas em mãos, interaja com o paciente para iniciar a cirurgia. Você poderá escolher qual parte deseja operar.
 
-## Ghetto Surgery
+  ## Cirurgia do Gueto
 
-Certain non-surgical tools can be used in a pinch, use the scalpel examine icon to see how good or bad something is.
+  Certos instrumentos não cirúrgicos podem ser usados em caso de emergência. Use o ícone de bisturi para examinar o paciente e verificar se algo está bom ou ruim.
 <Box>
 <GuideEntityEmbed Entity="Welder" Caption="welder"/>
 <GuideEntityEmbed Entity="Wirecutter" Caption="wirecutter"/>
@@ -47,6 +47,6 @@ Certain non-surgical tools can be used in a pinch, use the scalpel examine icon 
 <GuideEntityEmbed Entity="Crowbar" Caption="crowbar"/>
 </Box>
 
-They aren't ideal compared to real surgical equipment, but they'll do in a pinch!
+  Eles não são ideais se comparados aos equipamentos cirúrgicos reais, mas servem em caso de emergência!
 
 </Document>

--- a/Resources/ServerInfo/_Shitmed/Guidebook/Medical/UtilitySurgeries.xml
+++ b/Resources/ServerInfo/_Shitmed/Guidebook/Medical/UtilitySurgeries.xml
@@ -1,11 +1,11 @@
 <Document>
-# Utility Surgeries
+  # Cirurgias Utilitárias
 
-## Tend Wounds
+  ## Tratamento de Feridas
 
-Tend Wounds is a surgery that allows you to heal brute or burn damage from a patient without the need for topicals.
-To begin you need to open an incision on the patient's body, and then apply a Hemostat to it until the part is fully healed.
-At which point then you can close the incision with a Cautery.
+  Tratamento de Feridas é uma cirurgia que permite curar lesões brutas ou queimaduras de um paciente sem a necessidade de medicamentos tópicos.
+  Para começar, você precisa abrir uma incisão no corpo do paciente e, em seguida, aplicar um Hemostato até que a área esteja totalmente cicatrizada.
+  Nesse momento, você pode fechar a incisão com um Cautério.
 
 <Box>
 <GuideEntityEmbed Entity="Scalpel" Caption="scalpel"/>
@@ -13,12 +13,12 @@ At which point then you can close the incision with a Cautery.
 <GuideEntityEmbed Entity="Cautery" Caption="cautery"/>
 </Box>
 
-This surgery performs best the more damaged your patient is, especially if they are still alive. And allows you to bring otherwise unrecoverable
-patients, such as the dumb Technical Assistant that just walked into the burn chamber.
+  Esta cirurgia tem melhor desempenho quanto mais danificado o paciente estiver, especialmente se ele ainda estiver vivo. E permite que você traga pacientes irrecuperáveis,
+  como o Assistente Técnico idiota que acabou de entrar na câmara de queima.
 
-## Cavity Implant
+  ## Implante de Cavidade
 
-This surgery allows you to implant any Tiny or Small item into a patient's torso. To begin you need to open an incision, and then open their ribcage.
-Your patient cannot access the implanted item normally, though there may be uses for this, such as hiding the Nuclear Authentication Disk.
+  Esta cirurgia permite que você implante qualquer item pequeno ou minúsculo no tronco de um paciente. Para começar, você precisa fazer uma incisão e, em seguida, abrir a caixa torácica.
+  Seu paciente não consegue acessar o item implantado normalmente, embora possa haver usos para isso, como esconder o Disco de Autenticação Nuclear.
 
 </Document>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentação**
    - Todo o conteúdo textual dos guias de química e medicina foi traduzido do inglês para o português, incluindo títulos, descrições e instruções.
    - As seções abrangem categorias como produtos químicos, botânica, alimentos, narcóticos, toxinas, pirotecnia, procedimentos médicos, cirurgias, clonagem, criogenia e manipulação de órgãos/partes.
    - Estruturas e funcionalidades dos documentos permanecem inalteradas; apenas a linguagem foi localizada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->